### PR TITLE
Fix corner-case issues identified in testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "private": true,
-  "name": "template-for-proposals",
-  "description": "A repository template for ECMAScript proposals.",
+  "name": "proposal-intl-keep-trailing-zeros",
   "scripts": {
     "start": "npm run build-loose -- --watch",
     "build": "npm run build-loose -- --strict",
@@ -14,7 +13,7 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@tc39/ecma262-biblio": "^2.1.2909",
+    "@tc39/ecma262-biblio": "^2.1.3018",
     "@tc39/ecma402-biblio": "^2.1.1190",
     "ecmarkup": "^21.3.0"
   },

--- a/spec.emu
+++ b/spec.emu
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <meta charset="utf8">
 <link rel="stylesheet" href="./spec.css">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
@@ -97,9 +97,14 @@ contributors: Eemeli Aro
         1. Else,
           1. If _x_ is not ~negative-zero~, then
             1. Assert: _x_ is a mathematical value.
-            1. If _numberFormat_.[[Style]] is *"percent"*, set _x_ be 100 × _x_.
+            1. <ins>Let _magnitude_ be the base 10 logarithm of abs(_x_) rounded down to the nearest integer.</ins>
+            1. If _numberFormat_.[[Style]] is *"percent"*<del>, set _x_ be 100 × _x_.</del><ins>, then</ins>
+              1. <ins>Set _x_ to 100 × _x_.</ins>
+              1. <ins>If _magnitude_ < 0, set _stringDigitCount_ to _stringDigitCount_ + max(_magnitude_, -2).</ins>
+              1. <ins>Set _magnitude_ to _magnitude_ + 2.</ins>
             1. Set _exponent_ to ComputeExponent(_numberFormat_, _x_).
             1. Set _x_ to _x_ × 10<sup>-_exponent_</sup>.
+            1. <ins>If _magnitude_ < 0 and _exponent_ < 0, set _stringDigitCount_ to _stringDigitCount_ + max(_magnitude_, _exponent_).</ins>
           1. Let _formatNumberResult_ be FormatNumericToString(_numberFormat_, _x_<ins>, _stringDigitCount_</ins>).
           1. Let _n_ be _formatNumberResult_.[[FormattedString]].
           1. Set _x_ to _formatNumberResult_.[[RoundedNumber]].
@@ -162,7 +167,7 @@ contributors: Eemeli Aro
       <h1>
         PartitionNotationSubPattern (
           _numberFormat_: an Intl.NumberFormat,
-          _x_: <del>an Intl</del><ins>a</ins> mathematical value<del>,</del><ins> or ~negative-zero~.</ins>
+          _x_: <del>an Intl</del><ins>a</ins> mathematical value<ins> or ~negative-zero~</ins>,
           _n_: a String,
           _exponent_: an integer,
         ): a List of Records with fields [[Type]] (a String) and [[Value]] (a String)
@@ -405,6 +410,7 @@ contributors: Eemeli Aro
         </p>
         </ins>
       </emu-note>
+      <emu-grammar type="definition"><ins>ZeroDigits ::: `0` ZeroDigits?</ins></emu-grammar>
       <emu-grammar>StringNumericLiteral ::: StrWhiteSpace?</emu-grammar>
       <emu-alg>
         1. Return <del>0</del><ins>« 0, 0 »</ins>.
@@ -432,10 +438,16 @@ contributors: Eemeli Aro
       <emu-alg>
         1. Return <del>~positive-infinity~</del><ins>« ~positive-infinity~, 0 »</ins>.
       </emu-alg>
-      <emu-grammar>StrUnsignedDecimalLiteral ::: DecimalDigits `.` DecimalDigits? ExponentPart?</emu-grammar>
+      <emu-grammar>StrUnsignedDecimalLiteral ::: <del>DecimalDigits</del> <ins>ZeroDigits? NonZeroDigit DecimalDigits?</ins> `.` DecimalDigits? ExponentPart?</emu-grammar>
       <emu-alg>
-        1. Let _a_ be MV of the first |DecimalDigits|.
-        1. <ins>Let _m_ be the number of code points in the first |DecimalDigits|.</ins>
+        1. <del>Let _a_ be MV of the first |DecimalDigits|.</del>
+        1. <ins>If the first |DecimalDigits| is present, then</ins>
+          1. <ins>Let _m_ be the number of code points in the first |DecimalDigits|.</ins>
+          1. <ins>Let _a_ be the MV of |NonZeroDigit| × 10<sup>_m_</sup> plus the MV of the first |DecimalDigits|.</ins>
+          1. <ins>Set _m_ to 1 + _m_.</ins>
+        1. <ins>Else,</ins>
+          1. <ins>Let _m_ be 1.</ins>
+          1. <ins>Let _a_ be the MV of |NonZeroDigit|.</ins>
         1. If the second |DecimalDigits| is present, then
           1. Let _b_ be MV of the second |DecimalDigits|.
           1. Let _n_ be the number of code points in the second |DecimalDigits|.
@@ -445,19 +457,30 @@ contributors: Eemeli Aro
         1. If |ExponentPart| is present, let _e_ be MV of |ExponentPart|. Otherwise, let _e_ be 0.
         1. Return <ins>«</ins> (_a_ + (_b_ × 10<sup>-_n_</sup>)) × 10<sup>_e_</sup><ins>, _m_ + _n_ »</ins>.
       </emu-alg>
-      <emu-grammar>StrUnsignedDecimalLiteral ::: `.` DecimalDigits ExponentPart?</emu-grammar>
+      <emu-grammar>StrUnsignedDecimalLiteral ::: <ins>ZeroDigits?</ins> `.` DecimalDigits ExponentPart?</emu-grammar>
       <emu-alg>
         1. Let _b_ be MV of |DecimalDigits|.
         1. If |ExponentPart| is present, let _e_ be MV of |ExponentPart|. Otherwise, let _e_ be 0.
         1. Let _n_ be the number of code points in |DecimalDigits|.
-        1. Return <ins>«</ins> _b_ × 10<sup>_e_ - _n_</sup><ins>, _n_ ».</ins>
+        1. Return <ins>«</ins> _b_ × 10<sup>_e_ - _n_</sup><ins>, 1 + _n_ ».</ins>
       </emu-alg>
-      <emu-grammar>StrUnsignedDecimalLiteral ::: DecimalDigits ExponentPart?</emu-grammar>
+      <emu-grammar>StrUnsignedDecimalLiteral ::: <del>DecimalDigits</del> <ins>ZeroDigits? NonZeroDigit DecimalDigits?</ins> ExponentPart?</emu-grammar>
       <emu-alg>
-        1. Let _a_ be MV of |DecimalDigits|.
+        1. <del>Let _a_ be MV of |DecimalDigits|.</del>
+        1. <ins>If the |DecimalDigits| is present, then</ins>
+          1. <ins>Let _m_ be the number of code points in |DecimalDigits|.</ins>
+          1. <ins>Let _a_ be the MV of |NonZeroDigit| × 10<sup>_m_</sup> plus the MV of |DecimalDigits|.</ins>
+          1. <ins>Set _m_ to 1 + _m_.</ins>
+        1. <ins>Else,</ins>
+          1. <ins>Let _m_ be 1.</ins>
+          1. <ins>Let _a_ be the MV of the |NonZeroDigit|.</ins>
         1. <ins>Let _m_ be the number of code points in |DecimalDigits|.</ins>
         1. If |ExponentPart| is present, let _e_ be MV of |ExponentPart|. Otherwise, let _e_ be 0.
         1. Return <ins>«</ins> _a_ × 10<sup>_e_</sup><ins>, _m_ »</ins>.
+      </emu-alg>
+      <emu-grammar><ins>StrUnsignedDecimalLiteral ::: ZeroDigits ExponentPart?</ins></emu-grammar>
+      <emu-alg>
+        1. <ins>Return « 0, 0 ».</ins>
       </emu-alg>
     </emu-clause>
 

--- a/spec.emu
+++ b/spec.emu
@@ -415,18 +415,16 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
         1. If _f_ ≠ 0, then
           1. Let _k_ be the length of _m_.
           1. If _k_ ≤ _f_, then
-            1. Let _z_ be the String value consisting of _f_ + 1 - _k_ occurrences of the code unit 0x0030 (DIGIT ZERO).
+            1. <ins>Let _zn_ be _f_ + 1 - _k_.</ins>
+            1. Let _z_ be the String value consisting of <del>_f_ + 1 - _k_</del><ins>_zn_</ins> occurrences of the code unit 0x0030 (DIGIT ZERO).
             1. Set _m_ to the string-concatenation of _z_ and _m_.
             1. Set _k_ to _f_ + 1.
           1. <ins>Else,</ins>
-            1. <ins>Let _z_ be the empty String.</ins>
+            1. <ins>Let _zn_ be 0.</ins>
           1. Let _a_ be the first _k_ - _f_ code units of _m_, and let _b_ be the remaining _f_ code units of _m_.
           1. <del>Set _m_ to the string-concatenation of _a_, *"."*, and _b_.</del>
           1. Let _int_ be the length of _a_.
-          1. <ins>Let _sfc_ be _stringDigitCount_ - _int_.</ins>
-          1. <ins>If _n_ ≠ 0, then</ins>
-            1. <ins>Let _zn_ be the length of _z_.</ins>
-            1. <ins>Set _sfc_ to _sfc_ + _zn_.</ins>
+          1. <ins>If _n_ = 0, let _sfc_ be _stringDigitCount_ - _int_; else let _sfc_ be _stringDigitCount_ - _int_ + _zn_.</ins>
           1. <ins>Let _cut_ be _maxFraction_ - max(_sfc_, _minFraction_).</ins>
           1. <ins>Repeat, while _cut_ > 0 and the last code unit of _b_ is 0x0030 (DIGIT ZERO),</ins>
             1. <ins>Remove the last code unit from _b_.</ins>

--- a/spec.emu
+++ b/spec.emu
@@ -508,7 +508,7 @@ contributors: Eemeli Aro
         <ins class="block">
           <p>
             The conversion of a |StringNumericLiteral| to a mathematical value and a precision is similar overall to the determination of the NumericValue of a |NumericLiteral| (see <emu-xref href="#sec-literals-numeric-literals"></emu-xref>), but some of the details are different.
-            The result of StringIntlMV is a List value with two elements, a mathematical value and the count of decimal digits in the source text.
+            The result of StringIntlMV is a List value with two elements, a mathematical value and the count of significant decimal digits in the source text.
           </p>
         </ins>
       </emu-note>
@@ -581,7 +581,7 @@ contributors: Eemeli Aro
       <dl class="header">
         <dt>description</dt>
         <dd>
-          The returned List contains two values: a mathematical value corresponding to the source text, and the count of decimal digits in the source text.
+          The returned List contains two values: a mathematical value corresponding to the source text, and the count of significant decimal digits in the source text.
         </dd>
       </dl>
       <emu-alg>
@@ -592,6 +592,7 @@ contributors: Eemeli Aro
         1. Else,
           1. Let _a_ be MV of _intPart_.
           1. Let _m_ be the number of code points in _intPart_.
+          1. Assert: _m_ > 0.
           1. Let _z_ be the count of leading U+0030 (DIGIT ZERO) code points in _intPart_.
         1. If _fracPart_ is ~empty~, then
           1. Let _b_ be 0.
@@ -599,12 +600,11 @@ contributors: Eemeli Aro
         1. Else,
           1. Let _b_ be MV of _fracPart_.
           1. Let _n_ be the number of code points in _fracPart_.
+          1. Assert: _n_ > 0.
           1. If _a_ = 0, then
             1. Let _zn_ be the count of leading U+0030 (DIGIT ZERO) code points in _fracPart_.
             1. Set _z_ to _z_ + _zn_.
-        1. If _a_ = 0 and _b_ = 0, then
-          1. Set _m_ to 1.
-          1. Set _z_ to 0.
+        1. If _a_ = 0 and _b_ = 0, return « 0, 1 + _n_ ».
         1. Return « (_a_ + (_b_ × 10<sup>-_n_</sup>)) × 10<sup>_e_</sup>, _m_ + _n_ - _z_».
       </emu-alg>
     </emu-clause>
@@ -651,8 +651,9 @@ contributors: Eemeli Aro
             1. <ins>Set _stringDigitCount_ to 0.</ins>
           1. <del>If _rounded_ is *+0*<sub>𝔽</sub> and _intlMV_ &lt; 0, return ~negative-zero~.</del>
           1. <del>If _rounded_ is *+0*<sub>𝔽</sub>, return 0.</del>
-          1. <ins>If _rounded_ is *+0*<sub>𝔽</sub>, then</ins>
+          1. <ins>Else if _rounded_ is *+0*<sub>𝔽</sub>, then</ins>
             1. <ins>If _intlMV_ &lt; 0, set _intlMV_ to ~negative-zero~; else set _intlMV_ to 0.</ins>
+            1. NOTE: The value of _stringDigitCount_ is retained.
         1. Return <del>_intlMV_</del><ins>the Record { [[Value]]: _intlMV_, [[StringDigitCount]]: _stringDigitCount_ }</ins>.
       </emu-alg>
     </emu-clause>

--- a/spec.emu
+++ b/spec.emu
@@ -97,8 +97,7 @@ contributors: Eemeli Aro
         1. Else,
           1. If _x_ is not ~negative-zero~, then
             1. Assert: _x_ is a mathematical value.
-            1. <ins>If _x_ = 0, let _magnitude_ be -∞.</ins>
-            1. <ins>Else, let _magnitude_ be floor(log10(_x_)).</ins>
+            1. <ins>If _x_ = 0, let _magnitude_ be -∞; else let _magnitude_ be floor(log10(_x_)).</ins>
             1. If _numberFormat_.[[Style]] is *"percent"*<del>, set _x_ be 100 × _x_.</del><ins>, then</ins>
               1. <ins>Set _x_ to 100 × _x_.</ins>
               1. <ins>If _magnitude_ < 0, set _stringDigitCount_ to _stringDigitCount_ + max(_magnitude_, -2).</ins>
@@ -331,8 +330,7 @@ contributors: Eemeli Aro
           1. <ins>Repeat, while _cut_ > 0 and the last code unit of _b_ is 0x0030 (DIGIT ZERO),</ins>
             1. <ins>Remove the last code unit from _b_.</ins>
             1. <ins>Set _cut_ to _cut_ - 1.</ins>
-          1. <ins>If _b_ is the empty String, set _m_ to _a_.</ins>
-          1. <ins>Else, set _m_ to the string-concatenation of _a_, *"."*, and _b_.</ins>
+          1. <ins>If _b_ is the empty String, set _m_ to _a_; else set _m_ to the string-concatenation of _a_, *"."*, and _b_.</ins>
         1. Else,
           1. Let _int_ be the length of _m_.
         1. <del>Let _cut_ be _maxFraction_ - _minFraction_.</del>
@@ -523,14 +521,12 @@ contributors: Eemeli Aro
           1. <del>If _rounded_ is *+∞*<sub>𝔽</sub> and _intlMV_ &lt; 0, return ~negative-infinity~.</del>
           1. <del>If _rounded_ is *+∞*<sub>𝔽</sub>, return ~positive-infinity~.</del>
           1. <ins>If _rounded_ is *+∞*<sub>𝔽</sub>, then</ins>
-            1. <ins>If _intlMV_ &lt; 0, set _intlMV_ to ~negative-infinity~.</ins>
-            1. <ins>Else, set _intlMV_ to ~positive-infinity~.</ins>
+            1. <ins>If _intlMV_ &lt; 0, set _intlMV_ to ~negative-infinity~; else set _intlMV_ to ~positive-infinity~.</ins>
             1. <ins>Set _stringDigitCount_ to 0.</ins>
           1. <del>If _rounded_ is *+0*<sub>𝔽</sub> and _intlMV_ &lt; 0, return ~negative-zero~.</del>
           1. <del>If _rounded_ is *+0*<sub>𝔽</sub>, return 0.</del>
           1. <ins>If _rounded_ is *+0*<sub>𝔽</sub>, then</ins>
-            1. <ins>If _intlMV_ &lt; 0, set _intlMV_ to ~negative-zero~.</ins>
-            1. <ins>Else, set _intlMV_ to 0.</ins>
+            1. <ins>If _intlMV_ &lt; 0, set _intlMV_ to ~negative-zero~; else set _intlMV_ to 0.</ins>
         1. Return <del>_intlMV_</del><ins>the Record { [[Value]]: _intlMV_, [[StringDigitCount]]: _stringDigitCount_ }</ins>.
       </emu-alg>
     </emu-clause>

--- a/spec.emu
+++ b/spec.emu
@@ -7,6 +7,7 @@
 title: Keep trailing zeros in Intl.NumberFormat and Intl.PluralRules
 stage: 2.7
 contributors: Eemeli Aro
+location: https://tc39.es/proposal-intl-keep-trailing-zeros/
 </pre>
 
 <emu-clause id="numberformat-objects" number="16">
@@ -372,10 +373,9 @@ contributors: Eemeli Aro
           1. Assert: _e_ &lt; 0.
           1. Set _m_ to the string-concatenation of *"0."*, -(_e_ + 1) occurrences of the code unit 0x0030 (DIGIT ZERO), and _m_.
           1. Let _int_ be 1.
-        1. If _m_ contains the code unit 0x002E (FULL STOP) and _maxPrecision_ > _minPrecision_, then
-          1. <ins>Let _sdc_ be _stringDigitCount_.</ins>
-          1. <ins>If _x_ ≠ 0 and _e_ &lt; 0, set _sdc_ to _sdc_ - _e_.</ins>
-          1. Let _cut_ be _maxPrecision_ - <del>_minPrecision_</del><ins>max(_sdc_, _minPrecision_)</ins>.
+        1. <ins>Let _resolvedMinPrecision_ be max(_minPrecision_, _stringDigitCount_).</ins>
+        1. If _m_ contains the code unit 0x002E (FULL STOP) and _maxPrecision_ > <del>_minPrecision_</del><ins>_resolvedMinPrecision_</ins>, then
+          1. Let _cut_ be _maxPrecision_ - <del>_minPrecision_</del><ins>_resolvedMinPrecision_</ins>.
           1. Repeat, while _cut_ > 0 and the last code unit of _m_ is 0x0030 (DIGIT ZERO),
             1. Remove the last code unit from _m_.
             1. Set _cut_ to _cut_ - 1.
@@ -424,7 +424,7 @@ contributors: Eemeli Aro
           1. <del>Set _m_ to the string-concatenation of _a_, *"."*, and _b_.</del>
           1. Let _int_ be the length of _a_.
           1. <ins>Let _sfc_ be _stringDigitCount_ - _int_.</ins>
-          1. <ins>If _x_ ≠ 0, then</ins>
+          1. <ins>If _n_ ≠ 0, then</ins>
             1. <ins>Let _zn_ be the length of _z_.</ins>
             1. <ins>Set _sfc_ to _sfc_ + _zn_.</ins>
           1. <ins>Let _cut_ be _maxFraction_ - max(_sfc_, _minFraction_).</ins>

--- a/spec.emu
+++ b/spec.emu
@@ -195,14 +195,9 @@ contributors: Eemeli Aro
         1. Else,
           1. If _x_ is not ~negative-zero~, then
             1. Assert: _x_ is a mathematical value.
-            1. <ins>If _x_ = 0, let _magnitude_ be -∞; else let _magnitude_ be floor(log10(_x_)).</ins>
-            1. If _numberFormat_.[[Style]] is *"percent"*<del>, set _x_ be 100 × _x_.</del><ins>, then</ins>
-              1. <ins>Set _x_ to 100 × _x_.</ins>
-              1. <ins>If _magnitude_ < 0, set _stringDigitCount_ to _stringDigitCount_ + max(_magnitude_, -2).</ins>
-              1. <ins>Set _magnitude_ to _magnitude_ + 2.</ins>
+            1. If _numberFormat_.[[Style]] is *"percent"*, set _x_ be 100 × _x_.
             1. Set _exponent_ to ComputeExponent(_numberFormat_, _x_).
             1. Set _x_ to _x_ × 10<sup>-_exponent_</sup>.
-            1. <ins>If _magnitude_ < 0 and _exponent_ < 0, set _stringDigitCount_ to _stringDigitCount_ + max(_magnitude_, _exponent_).</ins>
           1. Let _formatNumberResult_ be FormatNumericToString(_numberFormat_, _x_<ins>, _stringDigitCount_</ins>).
           1. Let _n_ be _formatNumberResult_.[[FormattedString]].
           1. Set _x_ to _formatNumberResult_.[[RoundedNumber]].
@@ -378,7 +373,9 @@ contributors: Eemeli Aro
           1. Set _m_ to the string-concatenation of *"0."*, -(_e_ + 1) occurrences of the code unit 0x0030 (DIGIT ZERO), and _m_.
           1. Let _int_ be 1.
         1. If _m_ contains the code unit 0x002E (FULL STOP) and _maxPrecision_ > _minPrecision_, then
-          1. Let _cut_ be _maxPrecision_ - <del>_minPrecision_</del><ins>max(_stringDigitCount_, _minPrecision_)</ins>.
+          1. <ins>Let _sdc_ be _stringDigitCount_.</ins>
+          1. <ins>If _x_ ≠ 0 and _e_ &lt; 0, set _sdc_ to _sdc_ - _e_.</ins>
+          1. Let _cut_ be _maxPrecision_ - <del>_minPrecision_</del><ins>max(_sdc_, _minPrecision_)</ins>.
           1. Repeat, while _cut_ > 0 and the last code unit of _m_ is 0x0030 (DIGIT ZERO),
             1. Remove the last code unit from _m_.
             1. Set _cut_ to _cut_ - 1.
@@ -421,10 +418,16 @@ contributors: Eemeli Aro
             1. Let _z_ be the String value consisting of _f_ + 1 - _k_ occurrences of the code unit 0x0030 (DIGIT ZERO).
             1. Set _m_ to the string-concatenation of _z_ and _m_.
             1. Set _k_ to _f_ + 1.
+          1. <ins>Else,</ins>
+            1. <ins>Let _z_ be the empty String.</ins>
           1. Let _a_ be the first _k_ - _f_ code units of _m_, and let _b_ be the remaining _f_ code units of _m_.
           1. <del>Set _m_ to the string-concatenation of _a_, *"."*, and _b_.</del>
           1. Let _int_ be the length of _a_.
-          1. <ins>Let _cut_ be _maxFraction_ - max(_stringDigitCount_ - _int_, _minFraction_).</ins>
+          1. <ins>Let _sfc_ be _stringDigitCount_ - _int_.</ins>
+          1. <ins>If _x_ ≠ 0, then</ins>
+            1. <ins>Let _zn_ be the length of _z_.</ins>
+            1. <ins>Set _sfc_ to _sfc_ + _zn_.</ins>
+          1. <ins>Let _cut_ be _maxFraction_ - max(_sfc_, _minFraction_).</ins>
           1. <ins>Repeat, while _cut_ > 0 and the last code unit of _b_ is 0x0030 (DIGIT ZERO),</ins>
             1. <ins>Remove the last code unit from _b_.</ins>
             1. <ins>Set _cut_ to _cut_ - 1.</ins>
@@ -540,39 +543,41 @@ contributors: Eemeli Aro
       <emu-alg>
         1. Let _a_ be MV of the first |DecimalDigits|.
         1. <ins>Let _m_ be the number of code points in the first |DecimalDigits|.</ins>
-        1. <ins>Let _leadingZeroCount_ be the count of leading U+0030 (DIGIT ZERO) code points in the first |DecimalDigits|.</ins>
-        1. <ins>Set _m_ to max(1, _m_ - _leadingZeroCount_).</ins>
+        1. <ins>Let _z_ be the count of leading U+0030 (DIGIT ZERO) code points in the first |DecimalDigits|.</ins>
         1. If the second |DecimalDigits| is present, then
           1. Let _b_ be MV of the second |DecimalDigits|.
           1. Let _n_ be the number of code points in the second |DecimalDigits|.
+          1. <ins>If _a_ = 0, then</ins>
+            1. <ins>Let _zn_ be the count of leading U+0030 (DIGIT ZERO) code points in the second |DecimalDigits|.</ins>
+            1. <ins>Set _z_ to _z_ + _zn_.</ins>
         1. Else,
           1. Let _b_ be 0.
           1. Let _n_ be 0.
+        1. <ins>If _a_ = 0 and _b_ = 0, then</ins>
+          1. <ins>Set _m_ to 1.</ins>
+          1. <ins>Set _z_ to 0.</ins>
         1. If |ExponentPart| is present, let _e_ be MV of |ExponentPart|. Otherwise, let _e_ be 0.
-        1. <ins>If _m_ + _e_ &lt; 1, set _m_ to 1 - _e_.</ins>
-        1. Return <ins>«</ins> (_a_ + (_b_ × 10<sup>-_n_</sup>)) × 10<sup>_e_</sup><ins>, _m_ + _n_ »</ins>.
+        1. Return <ins>«</ins> (_a_ + (_b_ × 10<sup>-_n_</sup>)) × 10<sup>_e_</sup><ins>, _m_ + _n_ - _z_»</ins>.
       </emu-alg>
       <emu-grammar>StrUnsignedDecimalLiteral ::: `.` DecimalDigits ExponentPart?</emu-grammar>
       <emu-alg>
         1. Let _b_ be MV of |DecimalDigits|.
         1. If |ExponentPart| is present, let _e_ be MV of |ExponentPart|. Otherwise, let _e_ be 0.
-        1. <ins>If _e_ &lt; 0, let _m_ be 1 - _e_; else, let _m_ be 1.</ins>
         1. Let _n_ be the number of code points in |DecimalDigits|.
-        1. Return <ins>«</ins> _b_ × 10<sup>_e_ - _n_</sup><ins>, _m_ + _n_ ».</ins>
+        1. <ins>If _b_ = 0, let _z_ be 0; else let _z_ be the count of leading U+0030 (DIGIT ZERO) code points in |DecimalDigits|.</ins>
+        1. Return <ins>«</ins> _b_ × 10<sup>_e_ - _n_</sup><ins>, 1 + _n_ - _z_ ».</ins>
       </emu-alg>
       <emu-grammar>StrUnsignedDecimalLiteral ::: DecimalDigits ExponentPart?</emu-grammar>
       <emu-alg>
         1. Let _a_ be MV of |DecimalDigits|.
-        1. <ins>Let _m_ be the number of code points in |DecimalDigits|.</ins>
-        1. <ins>Let _leadingZeroCount_ be the count of leading U+0030 (DIGIT ZERO) code points in |DecimalDigits|.</ins>
-        1. <ins>Set _m_ to _m_ - _leadingZeroCount_.</ins>
         1. If |ExponentPart| is present, let _e_ be MV of |ExponentPart|. Otherwise, let _e_ be 0.
-        1. <ins>If _m_ + _e_ &lt; 1, set _m_ to 1 - _e_.</ins>
-        1. Return <ins>«</ins> _a_ × 10<sup>_e_</sup><ins>, _m_ »</ins>.
-      </emu-alg>
-      <emu-grammar><ins>StrUnsignedDecimalLiteral ::: ZeroDigits ExponentPart?</ins></emu-grammar>
-      <emu-alg>
-        1. <ins>Return « 0, 0 ».</ins>
+        1. <ins>If _a_ = 0, then</ins>
+          1. <ins>Let _m_ be 1.</ins>
+          1. <ins>Let _z_ be 0.</ins>
+        1. <ins>Else,</ins>
+          1. <ins>Let _m_ be the number of code points in |DecimalDigits|.</ins>
+          1. <ins>Let _z_ be the count of leading U+0030 (DIGIT ZERO) code points in |DecimalDigits|.</ins>
+        1. Return <ins>«</ins> _a_ × 10<sup>_e_</sup><ins>, _m_ - _z_ »</ins>.
       </emu-alg>
     </emu-clause>
 
@@ -587,7 +592,7 @@ contributors: Eemeli Aro
         <dd>
           It returns _value_ converted to an <dfn id="intl-mathematical-value">Intl mathematical value</dfn>, <del>which</del><ins>a Record with two fields:</ins>
           <ins>[[Value]]</ins> is a mathematical value <del>together with</del><ins>or one of</ins> ~positive-infinity~, ~negative-infinity~, ~not-a-number~, <ins>or ~negative-zero~,</ins> and
-          <del>~negative-zero~</del><ins>[[StringDigitCount]] is an integer indicating the number of significant digits in _value_ when it is a String, or 0 otherwise</ins>.
+          <del>~negative-zero~</del><ins>[[StringDigitCount]] is an integer indicating the number of decimal digits in _value_ when it is a String (ignoring any exponent, and not counting leading zeros), or 0 otherwise</ins>.
           This abstract operation is similar to <emu-xref href="#sec-tonumeric"></emu-xref>, but <del>a mathematical value can be returned instead of a Number or BigInt, so that exact decimal values can be represented</del><ins>retains the full precision of numeric strings</ins>.
         </dd>
       </dl>

--- a/spec.emu
+++ b/spec.emu
@@ -541,43 +541,71 @@ contributors: Eemeli Aro
       </emu-alg>
       <emu-grammar>StrUnsignedDecimalLiteral ::: DecimalDigits `.` DecimalDigits? ExponentPart?</emu-grammar>
       <emu-alg>
-        1. Let _a_ be MV of the first |DecimalDigits|.
-        1. <ins>Let _m_ be the number of code points in the first |DecimalDigits|.</ins>
-        1. <ins>Let _z_ be the count of leading U+0030 (DIGIT ZERO) code points in the first |DecimalDigits|.</ins>
-        1. If the second |DecimalDigits| is present, then
-          1. Let _b_ be MV of the second |DecimalDigits|.
-          1. Let _n_ be the number of code points in the second |DecimalDigits|.
-          1. <ins>If _a_ = 0, then</ins>
-            1. <ins>Let _zn_ be the count of leading U+0030 (DIGIT ZERO) code points in the second |DecimalDigits|.</ins>
-            1. <ins>Set _z_ to _z_ + _zn_.</ins>
-        1. Else,
-          1. Let _b_ be 0.
-          1. Let _n_ be 0.
-        1. <ins>If _a_ = 0 and _b_ = 0, then</ins>
-          1. <ins>Set _m_ to 1.</ins>
-          1. <ins>Set _z_ to 0.</ins>
-        1. If |ExponentPart| is present, let _e_ be MV of |ExponentPart|. Otherwise, let _e_ be 0.
-        1. Return <ins>«</ins> (_a_ + (_b_ × 10<sup>-_n_</sup>)) × 10<sup>_e_</sup><ins>, _m_ + _n_ - _z_»</ins>.
+        1. <del>Let _a_ be MV of the first |DecimalDigits|.</del>
+        1. <del>If the second |DecimalDigits| is present, then</del>
+          1. <del>Let _b_ be MV of the second |DecimalDigits|.</del>
+          1. <del>Let _n_ be the number of code points in the second |DecimalDigits|.</del>
+        1. <del>Else,</del>
+          1. <del>Let _b_ be 0.</del>
+          1. <del>Let _n_ be 0.</del>
+        1. <ins>Let _intPart_ be the first |DecimalDigits|.</ins>
+        1. <ins>If the second |DecimalDigits| is present, let _fracPart_ be the second |DecimalDigits|; else let _fracPart_ be ~empty~.</ins>
+        1. If |ExponentPart| is present, let _e_ be MV of |ExponentPart|<del>. Otherwise,</del><ins>; else</ins> let _e_ be 0.
+        1. Return <del>(_a_ + (_b_ × 10<sup>-_n_</sup>)) × 10<sup>_e_</sup></del><ins>StringIntlMVFromParts(_intPart_, _fracPart_, _e_)</ins>.
       </emu-alg>
       <emu-grammar>StrUnsignedDecimalLiteral ::: `.` DecimalDigits ExponentPart?</emu-grammar>
       <emu-alg>
-        1. Let _b_ be MV of |DecimalDigits|.
-        1. If |ExponentPart| is present, let _e_ be MV of |ExponentPart|. Otherwise, let _e_ be 0.
-        1. Let _n_ be the number of code points in |DecimalDigits|.
-        1. <ins>If _b_ = 0, let _z_ be 0; else let _z_ be the count of leading U+0030 (DIGIT ZERO) code points in |DecimalDigits|.</ins>
-        1. Return <ins>«</ins> _b_ × 10<sup>_e_ - _n_</sup><ins>, 1 + _n_ - _z_ ».</ins>
+        1. <del>Let _b_ be MV of |DecimalDigits|.</del>
+        1. If |ExponentPart| is present, let _e_ be MV of |ExponentPart|<del>. Otherwise,</del><ins>; else</ins> let _e_ be 0.
+        1. <del>Let _n_ be the number of code points in |DecimalDigits|.</del>
+        1. Return <del>_b_ × 10<sup>_e_ - _n_</sup></del><ins>StringIntlMVFromParts(~empty~, |DecimalDigits|, _e_)</ins>.
       </emu-alg>
       <emu-grammar>StrUnsignedDecimalLiteral ::: DecimalDigits ExponentPart?</emu-grammar>
       <emu-alg>
-        1. Let _a_ be MV of |DecimalDigits|.
-        1. If |ExponentPart| is present, let _e_ be MV of |ExponentPart|. Otherwise, let _e_ be 0.
-        1. <ins>If _a_ = 0, then</ins>
-          1. <ins>Let _m_ be 1.</ins>
-          1. <ins>Let _z_ be 0.</ins>
-        1. <ins>Else,</ins>
-          1. <ins>Let _m_ be the number of code points in |DecimalDigits|.</ins>
-          1. <ins>Let _z_ be the count of leading U+0030 (DIGIT ZERO) code points in |DecimalDigits|.</ins>
-        1. Return <ins>«</ins> _a_ × 10<sup>_e_</sup><ins>, _m_ - _z_ »</ins>.
+        1. <del>Let _a_ be MV of |DecimalDigits|.</del>
+        1. If |ExponentPart| is present, let _e_ be MV of |ExponentPart|<del>. Otherwise,</del><ins>; else</ins> let _e_ be 0.
+        1. Return <del>_a_ × 10<sup>_e_</sup></del><ins>StringIntlMVFromParts(|DecimalDigits|, ~empty~, _e_)</ins>.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-stringintlmvfromparts" type="abstract operation">
+      <h1>
+        <ins>
+          StringIntlMVFromParts (
+            _intPart_: a Parse Node or ~empty~,
+            _fracPart_: a Parse Node or ~empty~,
+            _e_: a mathematical value,
+          ): a List
+        </ins>
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>
+          The returned List contains two values: a mathematical value corresponding to the source text, and the count of decimal digits in the source text.
+        </dd>
+      </dl>
+      <emu-alg>
+        1. If _intPart_ is ~empty~, then
+          1. Let _a_ be 0.
+          1. Let _m_ be 0.
+          1. Let _z_ be 0.
+        1. Else,
+          1. Let _a_ be MV of _intPart_.
+          1. Let _m_ be the number of code points in _intPart_.
+          1. Let _z_ be the count of leading U+0030 (DIGIT ZERO) code points in _intPart_.
+        1. If _fracPart_ is ~empty~, then
+          1. Let _b_ be 0.
+          1. Let _n_ be 0.
+        1. Else,
+          1. Let _b_ be MV of _fracPart_.
+          1. Let _n_ be the number of code points in _fracPart_.
+          1. If _a_ = 0, then
+            1. Let _zn_ be the count of leading U+0030 (DIGIT ZERO) code points in _fracPart_.
+            1. Set _z_ to _z_ + _zn_.
+        1. If _a_ = 0 and _b_ = 0, then
+          1. Set _m_ to 1.
+          1. Set _z_ to 0.
+        1. Return « (_a_ + (_b_ × 10<sup>-_n_</sup>)) × 10<sup>_e_</sup>, _m_ + _n_ - _z_».
       </emu-alg>
     </emu-clause>
 

--- a/spec.emu
+++ b/spec.emu
@@ -509,7 +509,6 @@ contributors: Eemeli Aro
           </p>
         </ins>
       </emu-note>
-      <emu-grammar type="definition"><ins>ZeroDigits ::: `0` ZeroDigits?</ins></emu-grammar>
       <emu-grammar>StringNumericLiteral ::: StrWhiteSpace?</emu-grammar>
       <emu-alg>
         1. Return <del>0</del><ins>« 0, 0 »</ins>.
@@ -537,16 +536,12 @@ contributors: Eemeli Aro
       <emu-alg>
         1. Return <del>~positive-infinity~</del><ins>« ~positive-infinity~, 0 »</ins>.
       </emu-alg>
-      <emu-grammar>StrUnsignedDecimalLiteral ::: <del>DecimalDigits</del> <ins>ZeroDigits? NonZeroDigit DecimalDigits?</ins> `.` DecimalDigits? ExponentPart?</emu-grammar>
+      <emu-grammar>StrUnsignedDecimalLiteral ::: DecimalDigits `.` DecimalDigits? ExponentPart?</emu-grammar>
       <emu-alg>
-        1. <del>Let _a_ be MV of the first |DecimalDigits|.</del>
-        1. <ins>If the first |DecimalDigits| is present, then</ins>
-          1. <ins>Let _m_ be the number of code points in the first |DecimalDigits|.</ins>
-          1. <ins>Let _a_ be the MV of |NonZeroDigit| × 10<sup>_m_</sup> plus the MV of the first |DecimalDigits|.</ins>
-          1. <ins>Set _m_ to 1 + _m_.</ins>
-        1. <ins>Else,</ins>
-          1. <ins>Let _m_ be 1.</ins>
-          1. <ins>Let _a_ be the MV of |NonZeroDigit|.</ins>
+        1. Let _a_ be MV of the first |DecimalDigits|.
+        1. <ins>Let _m_ be the number of code points in the first |DecimalDigits|.</ins>
+        1. <ins>Let _leadingZeroCount_ be the count of leading U+0030 (DIGIT ZERO) code points in the first |DecimalDigits|.</ins>
+        1. <ins>Set _m_ to max(1, _m_ - _leadingZeroCount_).</ins>
         1. If the second |DecimalDigits| is present, then
           1. Let _b_ be MV of the second |DecimalDigits|.
           1. Let _n_ be the number of code points in the second |DecimalDigits|.
@@ -557,7 +552,7 @@ contributors: Eemeli Aro
         1. <ins>If _m_ + _e_ &lt; 1, set _m_ to 1 - _e_.</ins>
         1. Return <ins>«</ins> (_a_ + (_b_ × 10<sup>-_n_</sup>)) × 10<sup>_e_</sup><ins>, _m_ + _n_ »</ins>.
       </emu-alg>
-      <emu-grammar>StrUnsignedDecimalLiteral ::: <ins>ZeroDigits?</ins> `.` DecimalDigits ExponentPart?</emu-grammar>
+      <emu-grammar>StrUnsignedDecimalLiteral ::: `.` DecimalDigits ExponentPart?</emu-grammar>
       <emu-alg>
         1. Let _b_ be MV of |DecimalDigits|.
         1. If |ExponentPart| is present, let _e_ be MV of |ExponentPart|. Otherwise, let _e_ be 0.
@@ -565,16 +560,12 @@ contributors: Eemeli Aro
         1. Let _n_ be the number of code points in |DecimalDigits|.
         1. Return <ins>«</ins> _b_ × 10<sup>_e_ - _n_</sup><ins>, _m_ + _n_ ».</ins>
       </emu-alg>
-      <emu-grammar>StrUnsignedDecimalLiteral ::: <del>DecimalDigits</del> <ins>ZeroDigits? NonZeroDigit DecimalDigits?</ins> ExponentPart?</emu-grammar>
+      <emu-grammar>StrUnsignedDecimalLiteral ::: DecimalDigits ExponentPart?</emu-grammar>
       <emu-alg>
-        1. <del>Let _a_ be MV of |DecimalDigits|.</del>
-        1. <ins>If the |DecimalDigits| is present, then</ins>
-          1. <ins>Let _m_ be the number of code points in |DecimalDigits|.</ins>
-          1. <ins>Let _a_ be the MV of |NonZeroDigit| × 10<sup>_m_</sup> plus the MV of |DecimalDigits|.</ins>
-          1. <ins>Set _m_ to 1 + _m_.</ins>
-        1. <ins>Else,</ins>
-          1. <ins>Let _m_ be 1.</ins>
-          1. <ins>Let _a_ be the MV of the |NonZeroDigit|.</ins>
+        1. Let _a_ be MV of |DecimalDigits|.
+        1. <ins>Let _m_ be the number of code points in |DecimalDigits|.</ins>
+        1. <ins>Let _leadingZeroCount_ be the count of leading U+0030 (DIGIT ZERO) code points in |DecimalDigits|.</ins>
+        1. <ins>Set _m_ to _m_ - _leadingZeroCount_.</ins>
         1. If |ExponentPart| is present, let _e_ be MV of |ExponentPart|. Otherwise, let _e_ be 0.
         1. <ins>If _m_ + _e_ &lt; 1, set _m_ to 1 - _e_.</ins>
         1. Return <ins>«</ins> _a_ × 10<sup>_e_</sup><ins>, _m_ »</ins>.

--- a/spec.emu
+++ b/spec.emu
@@ -98,7 +98,7 @@ contributors: Eemeli Aro
           1. If _x_ is not ~negative-zero~, then
             1. Assert: _x_ is a mathematical value.
             1. <ins>If _x_ = 0, let _magnitude_ be -∞.</ins>
-            1. <ins>Else, let _magnitude_ be the base 10 logarithm of abs(_x_) rounded down to the nearest integer.</ins>
+            1. <ins>Else, let _magnitude_ be floor(log10(_x_)).</ins>
             1. If _numberFormat_.[[Style]] is *"percent"*<del>, set _x_ be 100 × _x_.</del><ins>, then</ins>
               1. <ins>Set _x_ to 100 × _x_.</ins>
               1. <ins>If _magnitude_ < 0, set _stringDigitCount_ to _stringDigitCount_ + max(_magnitude_, -2).</ins>
@@ -382,13 +382,13 @@ contributors: Eemeli Aro
           1. Return 0.
         1. If _x_ &lt; 0, then
           1. Let _x_ = -_x_.
-        1. Let _magnitude_ be the base 10 logarithm of _x_ rounded down to the nearest integer.
+        1. Let _magnitude_ be floor(log10(_x_)).
         1. Let _exponent_ be ComputeExponentForMagnitude(_numberFormat_, _magnitude_).
         1. Let _x_ be _x_ × 10<sup>-_exponent_</sup>.
         1. Let _formatNumberResult_ be FormatNumericToString(_numberFormat_, _x_<ins>, 0</ins>).
         1. If _formatNumberResult_.[[RoundedNumber]] = 0, then
           1. Return _exponent_.
-        1. Let _newMagnitude_ be the base 10 logarithm of _formatNumberResult_.[[RoundedNumber]] rounded down to the nearest integer.
+        1. Let _newMagnitude_ be floor(log10(_formatNumberResult_.[[RoundedNumber]])).
         1. If _newMagnitude_ is _magnitude_ - _exponent_, then
           1. Return _exponent_.
         1. Return ComputeExponentForMagnitude(_numberFormat_, _magnitude_ + 1).

--- a/spec.emu
+++ b/spec.emu
@@ -454,14 +454,16 @@ contributors: Eemeli Aro
           1. Let _b_ be 0.
           1. Let _n_ be 0.
         1. If |ExponentPart| is present, let _e_ be MV of |ExponentPart|. Otherwise, let _e_ be 0.
+        1. <ins>If _m_ + _e_ &lt; 1, set _m_ to 1 - _e_.</ins>
         1. Return <ins>«</ins> (_a_ + (_b_ × 10<sup>-_n_</sup>)) × 10<sup>_e_</sup><ins>, _m_ + _n_ »</ins>.
       </emu-alg>
       <emu-grammar>StrUnsignedDecimalLiteral ::: <ins>ZeroDigits?</ins> `.` DecimalDigits ExponentPart?</emu-grammar>
       <emu-alg>
         1. Let _b_ be MV of |DecimalDigits|.
         1. If |ExponentPart| is present, let _e_ be MV of |ExponentPart|. Otherwise, let _e_ be 0.
+        1. <ins>If _e_ &lt; 0, let _m_ be 1 - _e_; else, let _m_ be 1.</ins>
         1. Let _n_ be the number of code points in |DecimalDigits|.
-        1. Return <ins>«</ins> _b_ × 10<sup>_e_ - _n_</sup><ins>, 1 + _n_ ».</ins>
+        1. Return <ins>«</ins> _b_ × 10<sup>_e_ - _n_</sup><ins>, _m_ + _n_ ».</ins>
       </emu-alg>
       <emu-grammar>StrUnsignedDecimalLiteral ::: <del>DecimalDigits</del> <ins>ZeroDigits? NonZeroDigit DecimalDigits?</ins> ExponentPart?</emu-grammar>
       <emu-alg>
@@ -473,8 +475,8 @@ contributors: Eemeli Aro
         1. <ins>Else,</ins>
           1. <ins>Let _m_ be 1.</ins>
           1. <ins>Let _a_ be the MV of the |NonZeroDigit|.</ins>
-        1. <ins>Let _m_ be the number of code points in |DecimalDigits|.</ins>
         1. If |ExponentPart| is present, let _e_ be MV of |ExponentPart|. Otherwise, let _e_ be 0.
+        1. <ins>If _m_ + _e_ &lt; 1, set _m_ to 1 - _e_.</ins>
         1. Return <ins>«</ins> _a_ × 10<sup>_e_</sup><ins>, _m_ »</ins>.
       </emu-alg>
       <emu-grammar><ins>StrUnsignedDecimalLiteral ::: ZeroDigits ExponentPart?</ins></emu-grammar>

--- a/spec.emu
+++ b/spec.emu
@@ -97,7 +97,8 @@ contributors: Eemeli Aro
         1. Else,
           1. If _x_ is not ~negative-zero~, then
             1. Assert: _x_ is a mathematical value.
-            1. <ins>Let _magnitude_ be the base 10 logarithm of abs(_x_) rounded down to the nearest integer.</ins>
+            1. <ins>If _x_ = 0, let _magnitude_ be -∞.</ins>
+            1. <ins>Else, let _magnitude_ be the base 10 logarithm of abs(_x_) rounded down to the nearest integer.</ins>
             1. If _numberFormat_.[[Style]] is *"percent"*<del>, set _x_ be 100 × _x_.</del><ins>, then</ins>
               1. <ins>Set _x_ to 100 × _x_.</ins>
               1. <ins>If _magnitude_ < 0, set _stringDigitCount_ to _stringDigitCount_ + max(_magnitude_, -2).</ins>


### PR DESCRIPTION
While putting together tc39/test262#4608, I validated the proposed spec text with a [patched fork of FormatJS](https://github.com/eemeli/formatjs), and this identified a few places where the spec text needs to be updated:

- Leading zeros need to be discarded, so we count `'0012.3'` to have three string digits. To do so in the syntax-directed operation, I introduce `ZeroDigits` as a new syntax rule.

- An elided leading zero needs to be accounted for, so `'.45'` should count as having three string digits.

- Changes in exponents that reduce the number of leading zeros need to also reduce the string digit count accordingly. This means that when formatted as a percentage, `'0.06'` should format as if it had only one string digit, rather than three. This adjustment needs to be done potentially twice, as `style: 'percent'` can be combined with `notation: 'engineering'` or `notation: 'scientific'`.

Ping @sffc, @gibson042, @jessealama, @ben-allen for reviews.