### PR TITLE
Add `trailingZeroDisplay: 'stripToMinimum'` option value

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -12,7 +12,104 @@ contributors: Eemeli Aro
 <emu-clause id="numberformat-objects" number="16">
   <h1>NumberFormat Objects</h1>
 
-  <emu-clause id="sec-numberformat-abstracts" number="5">
+  <emu-clause id="sec-intl-numberformat-constructor">
+    <h1>The Intl.NumberFormat Constructor</h1>
+
+    <emu-clause id="sec-setnumberformatdigitoptions" oldids="sec-setnfdigitoptions" type="abstract operation" number="2">
+      <h1>
+        SetNumberFormatDigitOptions (
+          _intlObj_: an Object,
+          _options_: an Object,
+          _mnfdDefault_: an integer,
+          _mxfdDefault_: an integer,
+          _notation_: a String,
+        ): either a normal completion containing ~unused~ or a throw completion
+      </h1>
+      <dl class="header">
+        <dt>description</dt>
+        <dd>It populates the internal slots of _intlObj_ that affect locale-independent number rounding (see <emu-xref href="#sec-formatnumerictostring"></emu-xref>).</dd>
+      </dl>
+      <emu-alg>
+        1. Let _mnid_ be ? GetNumberOption(_options_, *"minimumIntegerDigits,"*, 1, 21, 1).
+        1. Let _mnfd_ be ? Get(_options_, *"minimumFractionDigits"*).
+        1. Let _mxfd_ be ? Get(_options_, *"maximumFractionDigits"*).
+        1. Let _mnsd_ be ? Get(_options_, *"minimumSignificantDigits"*).
+        1. Let _mxsd_ be ? Get(_options_, *"maximumSignificantDigits"*).
+        1. Set _intlObj_.[[MinimumIntegerDigits]] to _mnid_.
+        1. Let _roundingIncrement_ be ? GetNumberOption(_options_, *"roundingIncrement"*, 1, 5000, 1).
+        1. If _roundingIncrement_ is not in « 1, 2, 5, 10, 20, 25, 50, 100, 200, 250, 500, 1000, 2000, 2500, 5000 », throw a *RangeError* exception.
+        1. Let _roundingMode_ be ? GetOption(_options_, *"roundingMode"*, ~string~, « *"ceil"*, *"floor"*, *"expand"*, *"trunc"*, *"halfCeil"*, *"halfFloor"*, *"halfExpand"*, *"halfTrunc"*, *"halfEven"* », *"halfExpand"*).
+        1. Let _roundingPriority_ be ? GetOption(_options_, *"roundingPriority"*, ~string~, « *"auto"*, *"morePrecision"*, *"lessPrecision"* », *"auto"*).
+        1. Let _trailingZeroDisplay_ be ? GetOption(_options_, *"trailingZeroDisplay"*, ~string~, « *"auto"*, *"stripIfInteger"*<ins>, *"stripToMinimum"*</ins> », *"auto"*).
+        1. NOTE: All fields required by SetNumberFormatDigitOptions have now been read from _options_. The remainder of this AO interprets the options and may throw exceptions.
+        1. If _roundingIncrement_ is not 1, set _mxfdDefault_ to _mnfdDefault_.
+        1. Set _intlObj_.[[RoundingIncrement]] to _roundingIncrement_.
+        1. Set _intlObj_.[[RoundingMode]] to _roundingMode_.
+        1. Set _intlObj_.[[TrailingZeroDisplay]] to _trailingZeroDisplay_.
+        1. If _mnsd_ is *undefined* and _mxsd_ is *undefined*, let _hasSd_ be *false*. Otherwise, let _hasSd_ be *true*.
+        1. If _mnfd_ is *undefined* and _mxfd_ is *undefined*, let _hasFd_ be *false*. Otherwise, let _hasFd_ be *true*.
+        1. Let _needSd_ be *true*.
+        1. Let _needFd_ be *true*.
+        1. If _roundingPriority_ is *"auto"*, then
+          1. Set _needSd_ to _hasSd_.
+          1. If _needSd_ is *true*, or _hasFd_ is *false* and _notation_ is *"compact"*, then
+            1. Set _needFd_ to *false*.
+        1. If _needSd_ is *true*, then
+          1. If _hasSd_ is *true*, then
+            1. Set _intlObj_.[[MinimumSignificantDigits]] to ? DefaultNumberOption(_mnsd_, 1, 21, 1).
+            1. Set _intlObj_.[[MaximumSignificantDigits]] to ? DefaultNumberOption(_mxsd_, _intlObj_.[[MinimumSignificantDigits]], 21, 21).
+          1. Else,
+            1. Set _intlObj_.[[MinimumSignificantDigits]] to 1.
+            1. Set _intlObj_.[[MaximumSignificantDigits]] to 21.
+        1. If _needFd_ is *true*, then
+          1. If _hasFd_ is *true*, then
+            1. Set _mnfd_ to ? DefaultNumberOption(_mnfd_, 0, 100, *undefined*).
+            1. Set _mxfd_ to ? DefaultNumberOption(_mxfd_, 0, 100, *undefined*).
+            1. If _mnfd_ is *undefined*, set _mnfd_ to min(_mnfdDefault_, _mxfd_).
+            1. Else if _mxfd_ is *undefined*, set _mxfd_ to max(_mxfdDefault_, _mnfd_).
+            1. Else if _mnfd_ is greater than _mxfd_, throw a *RangeError* exception.
+            1. Set _intlObj_.[[MinimumFractionDigits]] to _mnfd_.
+            1. Set _intlObj_.[[MaximumFractionDigits]] to _mxfd_.
+          1. Else,
+            1. Set _intlObj_.[[MinimumFractionDigits]] to _mnfdDefault_.
+            1. Set _intlObj_.[[MaximumFractionDigits]] to _mxfdDefault_.
+        1. If _needSd_ is *false* and _needFd_ is *false*, then
+          1. Set _intlObj_.[[MinimumFractionDigits]] to 0.
+          1. Set _intlObj_.[[MaximumFractionDigits]] to 0.
+          1. Set _intlObj_.[[MinimumSignificantDigits]] to 1.
+          1. Set _intlObj_.[[MaximumSignificantDigits]] to 2.
+          1. Set _intlObj_.[[RoundingType]] to ~more-precision~.
+          1. Set _intlObj_.[[ComputedRoundingPriority]] to *"morePrecision"*.
+        1. Else if _roundingPriority_ is *"morePrecision"*, then
+          1. Set _intlObj_.[[RoundingType]] to ~more-precision~.
+          1. Set _intlObj_.[[ComputedRoundingPriority]] to *"morePrecision"*.
+        1. Else if _roundingPriority_ is *"lessPrecision"*, then
+          1. Set _intlObj_.[[RoundingType]] to ~less-precision~.
+          1. Set _intlObj_.[[ComputedRoundingPriority]] to *"lessPrecision"*.
+        1. Else if _hasSd_ is *true*, then
+          1. Set _intlObj_.[[RoundingType]] to ~significant-digits~.
+          1. Set _intlObj_.[[ComputedRoundingPriority]] to *"auto"*.
+        1. Else,
+          1. Set _intlObj_.[[RoundingType]] to ~fraction-digits~.
+          1. Set _intlObj_.[[ComputedRoundingPriority]] to *"auto"*.
+        1. If _roundingIncrement_ is not 1, then
+          1. If _intlObj_.[[RoundingType]] is not ~fraction-digits~, throw a *TypeError* exception.
+          1. If _intlObj_.[[MaximumFractionDigits]] is not _intlObj_.[[MinimumFractionDigits]], throw a *RangeError* exception.
+        1. Return ~unused~.
+      </emu-alg>
+    </emu-clause>
+  </emu-clause>
+
+  <emu-clause id="sec-properties-of-intl-numberformat-instances" number="4">
+    <h1>Properties of Intl.NumberFormat Instances</h1>
+
+    <ul>
+      <li>...</li>
+      <li>[[TrailingZeroDisplay]] is one of the String values *"auto"*<del> or</del><ins>,</ins> *"stripIfInteger"*<ins>, or *"stripToMinimum"*</ins>, indicating whether to <ins>retain them when possible,</ins> strip trailing zeros if the formatted number is an integer (i.e., has no non-zero fraction digit)<ins>, or strip them at positions beyond the minimum count of fraction or significant digits, as applicable</ins>.</li>
+    </ul>
+  </emu-clause>
+
+  <emu-clause id="sec-numberformat-abstracts">
     <h1>Abstract Operations for NumberFormat Objects</h1>
 
     <emu-clause id="sec-formatnumerictostring" oldids="sec-formatnumberstring" type="abstract operation" number="3">
@@ -37,6 +134,7 @@ contributors: Eemeli Aro
           1. If _x_ &lt; 0, let _sign_ be ~negative~; else let _sign_ be ~positive~.
           1. If _sign_ is ~negative~, then
             1. Set _x_ to -_x_.
+        1. <ins>If _intlObject_.[[TrailingZeroDisplay]] is *"stripToMinimum"*, set _stringDigitCount_ to 0.</ins>
         1. Let _unsignedRoundingMode_ be GetUnsignedRoundingMode(_intlObject_.[[RoundingMode]], _sign_).
         1. If _intlObject_.[[RoundingType]] is ~significant-digits~, then
           1. Let _result_ be ToRawPrecision(_x_, <ins>_stringDigitCount_,</ins> _intlObject_.[[MinimumSignificantDigits]], _intlObject_.[[MaximumSignificantDigits]], _unsignedRoundingMode_).
@@ -162,7 +260,7 @@ contributors: Eemeli Aro
       <h1>
         PartitionNotationSubPattern (
           _numberFormat_: an Intl.NumberFormat,
-          _x_: <del>an Intl</del><ins>a</ins> mathematical value<del>,</del><ins> or ~negative-zero~.</ins>
+          _x_: <del>an Intl</del><ins>a</ins> mathematical value<del>,</del><ins> or ~negative-zero~.</ins>,
           _n_: a String,
           _exponent_: an integer,
         ): a List of Records with fields [[Type]] (a String) and [[Value]] (a String)
@@ -395,14 +493,16 @@ contributors: Eemeli Aro
       </dl>
       <emu-note>
         <del class="block">
-        <p>The
- conversion of a |StringNumericLiteral| to a Number value is similar overall to the determination of the NumericValue of a |NumericLiteral| (see <emu-xref href="#sec-literals-numeric-literals"></emu-xref>), but some of the details are different.</p>
+          <p>
+            The
+            conversion of a |StringNumericLiteral| to a Number value is similar overall to the determination of the NumericValue of a |NumericLiteral| (see <emu-xref href="#sec-literals-numeric-literals"></emu-xref>), but some of the details are different.
+          </p>
         </del>
         <ins class="block">
-        <p>
-          The conversion of a |StringNumericLiteral| to a mathematical value and a precision is similar overall to the determination of the NumericValue of a |NumericLiteral| (see <emu-xref href="#sec-literals-numeric-literals"></emu-xref>), but some of the details are different.
-          The result of StringIntlMV is a List value with two elements, a mathematical value and the count of decimal digits in the source text.
-        </p>
+          <p>
+            The conversion of a |StringNumericLiteral| to a mathematical value and a precision is similar overall to the determination of the NumericValue of a |NumericLiteral| (see <emu-xref href="#sec-literals-numeric-literals"></emu-xref>), but some of the details are different.
+            The result of StringIntlMV is a List value with two elements, a mathematical value and the count of decimal digits in the source text.
+          </p>
         </ins>
       </emu-note>
       <emu-grammar>StringNumericLiteral ::: StrWhiteSpace?</emu-grammar>
@@ -580,7 +680,16 @@ contributors: Eemeli Aro
     </emu-clause>
   </emu-clause>
 
-  <emu-clause id="sec-intl-pluralrules-abstracts" number="5">
+  <emu-clause id="sec-properties-of-intl-pluralrules-instances">
+    <h1>Properties of Intl.PluralRules Instances</h1>
+
+    <ul>
+      <li>...</li>
+      <li>[[TrailingZeroDisplay]] is one of the String values *"auto"*<del> or</del><ins>,</ins> *"stripIfInteger"*<ins>, or *"stripToMinimum"*</ins>, indicating whether to <ins>retain them when possible,</ins> strip trailing zeros if the formatted number is an integer (i.e., has no non-zero fraction digit)<ins>, or strip them at positions beyond the minimum count of fraction or significant digits, as applicable</ins>.</li>
+    </ul>
+  </emu-clause>
+
+  <emu-clause id="sec-intl-pluralrules-abstracts">
     <h1>Abstract Operations for PluralRules Objects</h1>
 
     <emu-clause id="sec-resolveplural" type="abstract operation" number="2">


### PR DESCRIPTION
See also #1, #11

Allows for the current behaviour to be enabled by using `trailingZeroDisplay: 'stripToMinimum'`, a new option value.

Previously, this possibility was presented with the name "stripFromString", but "stripToMinimum" describes it more accurately, and more clearly extends the behaviour to also cover e.g. user-defined values, for which it's only incidental that they're first serialised as a string before formatting.