### PR TITLE
Use exponent-adjusted fraction digit precision when formatting values as zero

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -158,7 +158,7 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
             </tr>
           <tr>
             <td>
-              [[MVFractionDigitCount]]
+              [[StringFractionDigitCount]]
             </td>
             <td>
               a non-negative integer
@@ -178,7 +178,7 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
           _intlObject_: an Object,
           _x_: a mathematical value or ~negative-zero~,
           <ins>_stringDigitCount_: an integer,</ins>
-          <ins>_mvFractionDigitCount_: an integer,</ins>
+          <ins>_stringFractionDigitCount_: an integer,</ins>
         ): a Record with fields [[RoundedNumber]] (a mathematical value or ~negative-zero~) and [[FormattedString]] (a String)
       </h1>
       <dl class="header">
@@ -197,15 +197,15 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
             1. Set _x_ to -_x_.
         1. <ins>If _intlObject_.[[TrailingZeroDisplay]] is *"stripToMinimum"*, then</ins>
           1. <ins>Set _stringDigitCount_ to 0.</ins>
-          1. <ins>Set _mvFractionDigitCount_ to 0.</ins>
+          1. <ins>Set _stringFractionDigitCount_ to 0.</ins>
         1. Let _unsignedRoundingMode_ be GetUnsignedRoundingMode(_intlObject_.[[RoundingMode]], _sign_).
         1. If _intlObject_.[[RoundingType]] is ~significant-digits~, then
-          1. Let _result_ be ToRawPrecision(_x_, <ins>_stringDigitCount_, _mvFractionDigitCount_,</ins> _intlObject_.[[MinimumSignificantDigits]], _intlObject_.[[MaximumSignificantDigits]], _unsignedRoundingMode_).
+          1. Let _result_ be ToRawPrecision(_x_, <ins>_stringDigitCount_, _stringFractionDigitCount_,</ins> _intlObject_.[[MinimumSignificantDigits]], _intlObject_.[[MaximumSignificantDigits]], _unsignedRoundingMode_).
         1. Else if _intlObject_.[[RoundingType]] is ~fraction-digits~, then
-          1. Let _result_ be ToRawFixed(_x_, <ins>_stringDigitCount_, _mvFractionDigitCount_,</ins> _intlObject_.[[MinimumFractionDigits]], _intlObject_.[[MaximumFractionDigits]], _intlObject_.[[RoundingIncrement]], _unsignedRoundingMode_).
+          1. Let _result_ be ToRawFixed(_x_, <ins>_stringDigitCount_, _stringFractionDigitCount_,</ins> _intlObject_.[[MinimumFractionDigits]], _intlObject_.[[MaximumFractionDigits]], _intlObject_.[[RoundingIncrement]], _unsignedRoundingMode_).
         1. Else,
-          1. Let _sResult_ be ToRawPrecision(_x_, <ins>_stringDigitCount_, _mvFractionDigitCount_,</ins> _intlObject_.[[MinimumSignificantDigits]], _intlObject_.[[MaximumSignificantDigits]], _unsignedRoundingMode_).
-          1. Let _fResult_ be ToRawFixed(_x_, <ins>_stringDigitCount_, _mvFractionDigitCount_,</ins> _intlObject_.[[MinimumFractionDigits]], _intlObject_.[[MaximumFractionDigits]], _intlObject_.[[RoundingIncrement]], _unsignedRoundingMode_).
+          1. Let _sResult_ be ToRawPrecision(_x_, <ins>_stringDigitCount_, _stringFractionDigitCount_,</ins> _intlObject_.[[MinimumSignificantDigits]], _intlObject_.[[MaximumSignificantDigits]], _unsignedRoundingMode_).
+          1. Let _fResult_ be ToRawFixed(_x_, <ins>_stringDigitCount_, _stringFractionDigitCount_,</ins> _intlObject_.[[MinimumFractionDigits]], _intlObject_.[[MaximumFractionDigits]], _intlObject_.[[RoundingIncrement]], _unsignedRoundingMode_).
           1. If _fResult_.[[RoundingMagnitude]] &lt; _sResult_.[[RoundingMagnitude]], let _fixedIsMorePrecise_ be *true*; else let _fixedIsMorePrecise_ be *false*.
           1. If _intlObject_.[[RoundingType]] is ~more-precision~ and _fixedIsMorePrecise_ is *true*, then
             1. Let _result_ be _fResult_.
@@ -244,12 +244,12 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
       <emu-alg>
         1. <ins>If _x_ is an Intl MV Record, then</ins>
           1. <ins>Let _stringDigitCount_ be _x_.[[StringDigitCount]].</ins>
-          1. <ins>Let _mvFractionDigitCount_ be _x_.[[MVFractionDigitCount]].</ins>
+          1. <ins>Let _stringFractionDigitCount_ be _x_.[[StringFractionDigitCount]].</ins>
           1. <ins>Set _x_ to _x_.[[Value]].</ins>
         1. <ins>Else,</ins>
           1. <ins>Assert: _x_ is a mathematical value.</ins>
           1. <ins>Let _stringDigitCount_ be 0.</ins>
-          1. <ins>Let _mvFractionDigitCount_ be 0.</ins>
+          1. <ins>Let _stringFractionDigitCount_ be 0.</ins>
         1. Let _exponent_ be 0.
         1. If _x_ is ~not-a-number~, then
           1. Let _n_ be an ILD String value indicating the *NaN* value.
@@ -263,7 +263,7 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
             1. If _numberFormat_.[[Style]] is *"percent"*, set _x_ <del>be</del><ins>to</ins> 100 × _x_.
             1. Set _exponent_ to ComputeExponent(_numberFormat_, _x_).
             1. Set _x_ to _x_ × 10<sup>-_exponent_</sup>.
-          1. Let _formatNumberResult_ be FormatNumericToString(_numberFormat_, _x_<ins>, _stringDigitCount_, _mvFractionDigitCount_</ins>).
+          1. Let _formatNumberResult_ be FormatNumericToString(_numberFormat_, _x_<ins>, _stringDigitCount_, _stringFractionDigitCount_</ins>).
           1. Let _n_ be _formatNumberResult_.[[FormattedString]].
           1. Set _x_ to _formatNumberResult_.[[RoundedNumber]].
         1. Let _pattern_ be GetNumberFormatPattern(_numberFormat_, _x_).
@@ -395,7 +395,7 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
         ToRawPrecision (
           _x_: a non-negative mathematical value,
           <ins>_stringDigitCount_: an integer,</ins>
-          <ins>_mvFractionDigitCount_: an integer,</ins>
+          <ins>_stringFractionDigitCount_: an integer,</ins>
           _minPrecision_: an integer in the inclusive interval from 1 to 21,
           _maxPrecision_: an integer in the inclusive interval from 1 to 21,
           _unsignedRoundingMode_: a specification type from the Unsigned Rounding Mode column of <emu-xref href="#table-intl-unsigned-rounding-modes"></emu-xref>, or *undefined*,
@@ -439,7 +439,7 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
           1. Assert: _e_ &lt; 0.
           1. Set _m_ to the string-concatenation of *"0."*, -(_e_ + 1) occurrences of the code unit 0x0030 (DIGIT ZERO), and _m_.
           1. Let _int_ be 1.
-        1. <ins>If _isZero_ is *true*, let _resolvedMinPrecision_ be max(_minPrecision_, _mvFractionDigitCount_ + 1); else let _resolvedMinPrecision_ be max(_minPrecision_, _stringDigitCount_).</ins>
+        1. <ins>If _isZero_ is *true*, let _resolvedMinPrecision_ be max(_minPrecision_, _stringFractionDigitCount_ + 1); else let _resolvedMinPrecision_ be max(_minPrecision_, _stringDigitCount_).</ins>
         1. If _m_ contains the code unit 0x002E (FULL STOP) and _maxPrecision_ > <del>_minPrecision_</del><ins>_resolvedMinPrecision_</ins>, then
           1. Let _cut_ be _maxPrecision_ - <del>_minPrecision_</del><ins>_resolvedMinPrecision_</ins>.
           1. Repeat, while _cut_ > 0 and the last code unit of _m_ is 0x0030 (DIGIT ZERO),
@@ -456,7 +456,7 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
         ToRawFixed (
           _x_: a non-negative mathematical value,
           <ins>_stringDigitCount_: an integer,</ins>
-          <ins>_mvFractionDigitCount_: an integer,</ins>
+          <ins>_stringFractionDigitCount_: an integer,</ins>
           _minFraction_: an integer in the inclusive interval from 0 to 100,
           _maxFraction_: an integer in the inclusive interval from 0 to 100,
           _roundingIncrement_: an integer,
@@ -492,7 +492,7 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
           1. <del>Set _m_ to the string-concatenation of _a_, *"."*, and _b_.</del>
           1. Let _int_ be the length of _a_.
           1. <ins>If every code unit of _m_ is 0x0030 (DIGIT ZERO), then</ins>
-            1. <ins>Let _sfc_ be _mvFractionDigitCount_.</ins>
+            1. <ins>Let _sfc_ be _stringFractionDigitCount_.</ins>
           1. <ins>Else if _n_ = 0, then</ins>
             1. <ins>Let _sfc_ be _stringDigitCount_ - _int_.</ins>
           1. <ins>Else,</ins>
@@ -586,7 +586,7 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
       </emu-note>
       <emu-grammar>StringNumericLiteral ::: StrWhiteSpace?</emu-grammar>
       <emu-alg>
-        1. Return <del>0</del><ins>the Intl MV Record { [[Value]]: 0, [[StringDigitCount]]: 0, [[MVFractionDigitCount]]: 0 }</ins>.
+        1. Return <del>0</del><ins>the Intl MV Record { [[Value]]: 0, [[StringDigitCount]]: 0, [[StringFractionDigitCount]]: 0 }</ins>.
       </emu-alg>
       <emu-grammar>StringNumericLiteral ::: StrWhiteSpace? StrNumericLiteral StrWhiteSpace?</emu-grammar>
       <emu-alg>
@@ -596,7 +596,7 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
       <emu-alg>
         1. <del>Return MV of |NonDecimalIntegerLiteral|.</del>
         1. <ins>Let _i_ be MV of |NonDecimalIntegerLiteral|.</ins>
-        1. <ins>Return the Intl MV Record { [[Value]]: _i_, [[StringDigitCount]]: 0, [[MVFractionDigitCount]]: 0 }.</ins>
+        1. <ins>Return the Intl MV Record { [[Value]]: _i_, [[StringDigitCount]]: 0, [[StringFractionDigitCount]]: 0 }.</ins>
       </emu-alg>
       <emu-grammar>StrDecimalLiteral ::: `-` StrUnsignedDecimalLiteral</emu-grammar>
       <emu-alg>
@@ -609,7 +609,7 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
       </emu-alg>
       <emu-grammar>StrUnsignedDecimalLiteral ::: `Infinity`</emu-grammar>
       <emu-alg>
-        1. Return <del>~positive-infinity~</del><ins>the Intl MV Record { [[Value]]: ~positive-infinity~, [[StringDigitCount]]: 0, [[MVFractionDigitCount]]: 0 }</ins>.
+        1. Return <del>~positive-infinity~</del><ins>the Intl MV Record { [[Value]]: ~positive-infinity~, [[StringDigitCount]]: 0, [[StringFractionDigitCount]]: 0 }</ins>.
       </emu-alg>
       <emu-grammar>StrUnsignedDecimalLiteral ::: DecimalDigits `.` DecimalDigits? ExponentPart?</emu-grammar>
       <emu-alg>
@@ -677,8 +677,8 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
           1. If _a_ = 0 and _b_ = 0, return « 0, 1 + _n_ ».
           1. Let _value_ be (_a_ + (_b_ × 10<sup>-_n_</sup>)) × 10<sup>_e_</sup>.
           1. Let _stringDigitCount_ be _m_ + _n_ - _z_.
-          1. Let _mvFractionDigitCount_ be max(0, _n_ - _e_).
-          1. Return the Intl MV Record { [[Value]]: _value_, [[StringDigitCount]]: _stringDigitCount_, [[MVFractionDigitCount]]: _mvFractionDigitCount_ }.
+          1. Let _stringFractionDigitCount_ be max(0, _n_ - _e_).
+          1. Return the Intl MV Record { [[Value]]: _value_, [[StringDigitCount]]: _stringDigitCount_, [[StringFractionDigitCount]]: _stringFractionDigitCount_ }.
         </emu-alg>
       </emu-clause>
     </ins>
@@ -698,24 +698,24 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
       </dl>
       <emu-alg>
         1. Let _primValue_ be ? ToPrimitive(_value_, ~number~).
-        1. If _primValue_ is a BigInt, return <del>ℝ(_primValue_)</del><ins>the Intl MV Record { [[Value]]: ℝ(_primValue_), [[StringDigitCount]]: 0, [[MVFractionDigitCount]]: 0 }</ins>.
+        1. If _primValue_ is a BigInt, return <del>ℝ(_primValue_)</del><ins>the Intl MV Record { [[Value]]: ℝ(_primValue_), [[StringDigitCount]]: 0, [[StringFractionDigitCount]]: 0 }</ins>.
         1. If _primValue_ is a String, then
           1. Let _str_ be _primValue_.
         1. Else,
           1. Let _x_ be ? ToNumber(_primValue_).
-          1. If _x_ is *-0*<sub>𝔽</sub>, return <del>~negative-zero~</del><ins>the Intl MV Record { [[Value]]: ~negative-zero~, [[StringDigitCount]]: 0, [[MVFractionDigitCount]]: 0 }</ins>.
+          1. If _x_ is *-0*<sub>𝔽</sub>, return <del>~negative-zero~</del><ins>the Intl MV Record { [[Value]]: ~negative-zero~, [[StringDigitCount]]: 0, [[StringFractionDigitCount]]: 0 }</ins>.
           1. Let _str_ be Number::toString(_x_, 10).
         1. Let _text_ be StringToCodePoints(_str_).
         1. Let _literal_ be ParseText(_text_, |StringNumericLiteral|).
-        1. If _literal_ is a List of errors, return <del>~not-a-number~</del><ins>the Intl MV Record { [[Value]]: ~not-a-number~, [[StringDigitCount]]: 0, [[MVFractionDigitCount]]: 0 }</ins>.
+        1. If _literal_ is a List of errors, return <del>~not-a-number~</del><ins>the Intl MV Record { [[Value]]: ~not-a-number~, [[StringDigitCount]]: 0, [[StringFractionDigitCount]]: 0 }</ins>.
         1. Let <del>_intlMV_</del><ins>_stringData_</ins> be the StringIntlMV of _literal_.
         1. <ins>Let _value_ be _stringData_.[[Value]].</ins>
         1. <ins>If _primValue_ is a String, then</ins>
           1. <ins>Let _stringDigitCount_ be _stringData_.[[StringDigitCount]].</ins>
-          1. <ins>Let _mvFractionDigitCount_ be _stringData_.[[MVFractionDigitCount]].</ins>
+          1. <ins>Let _stringFractionDigitCount_ be _stringData_.[[StringFractionDigitCount]].</ins>
         1. <ins>Else,</ins>
           1. <ins>Let _stringDigitCount_ be 0.</ins>
-          1. <ins>Let _mvFractionDigitCount_ be 0.</ins>
+          1. <ins>Let _stringFractionDigitCount_ be 0.</ins>
         1. If <del>_intlMV_</del><ins>_value_</ins> is a mathematical value, then
           1. Let _rounded_ be RoundMVResult(abs(<del>_intlMV_</del><ins>_value_</ins>)).
           1. <del>If _rounded_ is *+∞*<sub>𝔽</sub> and _intlMV_ &lt; 0, return ~negative-infinity~.</del>
@@ -728,7 +728,7 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
           1. <ins>Else if _rounded_ is *+0*<sub>𝔽</sub>, then</ins>
             1. <ins>If _value_ &lt; 0, set _value_ to ~negative-zero~; else set _value_ to 0.</ins>
             1. NOTE: The value of _stringDigitCount_ is retained.
-        1. Return <del>_intlMV_</del><ins>the Intl MV Record { [[Value]]: _value_, [[StringDigitCount]]: _stringDigitCount_, [[MVFractionDigitCount]]: _mvFractionDigitCount_ }</ins>.
+        1. Return <del>_intlMV_</del><ins>the Intl MV Record { [[Value]]: _value_, [[StringDigitCount]]: _stringDigitCount_, [[StringFractionDigitCount]]: _stringFractionDigitCount_ }</ins>.
       </emu-alg>
     </emu-clause>
 
@@ -805,8 +805,8 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
           1. Let _s_ be an ILD String value indicating negative infinity.
           1. Return the Record { [[PluralCategory]]: *"other"*, [[FormattedString]]: _s_ }.
         1. <ins>Let _stringDigitCount_ be _intlMV_.[[StringDigitCount]].</ins>
-        1. <ins>Let _mvFractionDigitCount_ be _intlMV_.[[MVFractionDigitCount]].</ins>
-        1. Let _res_ be FormatNumericToString(_pluralRules_, _n_<ins>, _stringDigitCount_, _mvFractionDigitCount_</ins>).
+        1. <ins>Let _stringFractionDigitCount_ be _intlMV_.[[StringFractionDigitCount]].</ins>
+        1. Let _res_ be FormatNumericToString(_pluralRules_, _n_<ins>, _stringDigitCount_, _stringFractionDigitCount_</ins>).
         1. Let _s_ be _res_.[[FormattedString]].
         1. Let _locale_ be _pluralRules_.[[Locale]].
         1. Let _type_ be _pluralRules_.[[Type]].

--- a/spec.emu
+++ b/spec.emu
@@ -151,7 +151,7 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
               a non-negative integer
             </td>
             <td>
-              The number of decimal digits in [[Value]] when it is derived from a String (ignoring any exponent, and not counting leading zeros), or 0 otherwise.
+              The number of decimal digits in [[Value]] when it is derived from a String (before applying its exponent part, and ignoring leading zeros), or 0 otherwise.
             </td>
           </tr>
         </table>
@@ -576,8 +576,8 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
         1. Let <del>_a_</del><ins>_x_</ins> be StringIntlMV of |StrUnsignedDecimalLiteral|.
         1. <ins>Let _a_ be the first element of _x_.</ins>
         1. <ins>Let _n_ be the second element of _x_.</ins>
-        1. If _a_ is 0, return <del>~negative-zero~</del><ins>« ~negative-zero~, _n_ »</ins>.
-        1. If _a_ is ~positive-infinity~, return <del>~negative-infinity~</del><ins>« ~negative-infinity~, 0 »</ins>.
+        1. If _a_ is 0, return <del>~negative-zero~</del><ins>the Intl MV Record { [[Value]]: ~negative-zero~, [[StringDigitCount]]: _n_ }</ins>.
+        1. If _a_ is ~positive-infinity~, return <del>~negative-infinity~</del><ins>the Intl MV Record { [[Value]]: ~negative-infinity~, [[StringDigitCount]]: 0 }</ins>.
         1. Return <del>-_a_</del><ins>the Intl MV Record { [[Value]]: -_a_, [[StringDigitCount]]: _n_ }</ins>.
       </emu-alg>
       <emu-grammar>StrUnsignedDecimalLiteral ::: `Infinity`</emu-grammar>
@@ -706,7 +706,7 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
         PartitionNumberRangePattern (
           _numberFormat_: an Intl.NumberFormat,
           _x_: an <del>Intl mathematical value</del><ins>Intl MV Record</ins>,
-          _y_: an <del>mIntl athematical value</del><ins>Intl MV Record</ins>,
+          _y_: an <del>Intl mathematical value</del><ins>Intl MV Record</ins>,
         ): either a normal completion containing a List of Records with fields [[Type]] (a String), [[Value]] (a String), and [[Source]] (a String), or a throw completion
       </h1>
       <dl class="header">

--- a/spec.emu
+++ b/spec.emu
@@ -674,9 +674,8 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
             1. If _a_ = 0, then
               1. Let _zn_ be the count of leading U+0030 (DIGIT ZERO) code points in _fracPart_.
               1. Set _z_ to _z_ + _zn_.
-          1. If _a_ = 0 and _b_ = 0, return « 0, 1 + _n_ ».
           1. Let _value_ be (_a_ + (_b_ × 10<sup>-_n_</sup>)) × 10<sup>_e_</sup>.
-          1. Let _stringDigitCount_ be _m_ + _n_ - _z_.
+          1. If _a_ = 0 and _b_ = 0, let _stringDigitCount_ be 1 + _n_; else let _stringDigitCount_ be _m_ + _n_ - _z_.
           1. Let _stringFractionDigitCount_ be max(0, _n_ - _e_).
           1. Return the Intl MV Record { [[Value]]: _value_, [[StringDigitCount]]: _stringDigitCount_, [[StringFractionDigitCount]]: _stringFractionDigitCount_ }.
         </emu-alg>

--- a/spec.emu
+++ b/spec.emu
@@ -113,50 +113,53 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
   <emu-clause id="sec-numberformat-abstracts">
     <h1>Abstract Operations for NumberFormat Objects</h1>
 
-    <emu-clause id="sec-intl-mv-records">
-      <h1><ins>Intl MV Records</ins></h1>
-      <p>An <dfn variants="Intl MV Records">Intl MV Record</dfn> is a Record value used to encapsulate a mathematical value together with additional information.</p>
-      <p>Intl MV Records have the fields listed in <emu-xref href="#table-intl-mv-record-fields"></emu-xref>.</p>
-      <emu-table id="table-intl-mv-record-fields" caption="Intl MV Record Fields">
-        <table>
-          <thead>
+    <ins class="block">
+
+      <emu-clause id="sec-intl-mv-records">
+        <h1><ins>Intl MV Records</ins></h1>
+        <p>An <dfn variants="Intl MV Records">Intl MV Record</dfn> is a Record value used to encapsulate a mathematical value together with additional information.</p>
+        <p>Intl MV Records have the fields listed in <emu-xref href="#table-intl-mv-record-fields"></emu-xref>.</p>
+        <emu-table id="table-intl-mv-record-fields" caption="Intl MV Record Fields">
+          <table>
+            <thead>
+              <tr>
+                <th>
+                  Field Name
+                </th>
+                <th>
+                  Value
+                </th>
+                <th>
+                  Meaning
+                </th>
+              </tr>
+            </thead>
             <tr>
-              <th>
-                Field Name
-              </th>
-              <th>
-                Value
-              </th>
-              <th>
-                Meaning
-              </th>
+              <td>
+                [[Value]]
+              </td>
+              <td>
+                a mathematical value or one of ~positive-infinity~, ~negative-infinity~, ~not-a-number~, or ~negative-zero~
+              </td>
+              <td>
+                The value being formatted or selected on.
+              </td>
             </tr>
-          </thead>
-          <tr>
-            <td>
-              [[Value]]
-            </td>
-            <td>
-              a mathematical value or one of ~positive-infinity~, ~negative-infinity~, ~not-a-number~, or ~negative-zero~
-            </td>
-            <td>
-              The value being formatted or selected on.
-            </td>
-          </tr>
-          <tr>
-            <td>
-              [[StringDigitCount]]
-            </td>
-            <td>
-              a non-negative integer
-            </td>
-            <td>
-              The number of decimal digits in [[Value]] when it is derived from a String (before applying its exponent part, and ignoring leading zeros), or 0 otherwise.
-            </td>
-          </tr>
-        </table>
-      </emu-table>
-    </emu-clause>
+            <tr>
+              <td>
+                [[StringDigitCount]]
+              </td>
+              <td>
+                a non-negative integer
+              </td>
+              <td>
+                The number of decimal digits in [[Value]] when it is derived from a String (before applying its exponent part, and ignoring leading zeros), or 0 otherwise.
+              </td>
+            </tr>
+          </table>
+        </emu-table>
+      </emu-clause>
+    </ins>
 
     <emu-clause id="sec-formatnumerictostring" oldids="sec-formatnumberstring" type="abstract operation" number="3">
       <h1>
@@ -613,46 +616,47 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-stringintlmvfromparts" type="abstract operation">
-      <h1>
-        <ins>
-          StringIntlMVFromParts (
+    <ins class="block">
+
+      <emu-clause id="sec-stringintlmvfromparts" type="abstract operation">
+        <h1>
+          <ins>StringIntlMVFromParts (
             _intPart_: a Parse Node or ~empty~,
             _fracPart_: a Parse Node or ~empty~,
             _e_: a mathematical value,
-          ): an Intl MV Record
-        </ins>
-      </h1>
-      <dl class="header">
-        <dt>description</dt>
-        <dd></dd>
-      </dl>
-      <emu-alg>
-        1. If _intPart_ is ~empty~, then
-          1. Let _a_ be 0.
-          1. Let _m_ be 0.
-          1. Let _z_ be 0.
-        1. Else,
-          1. Let _a_ be MV of _intPart_.
-          1. Let _m_ be the number of code points in _intPart_.
-          1. Assert: _m_ > 0.
-          1. Let _z_ be the count of leading U+0030 (DIGIT ZERO) code points in _intPart_.
-        1. If _fracPart_ is ~empty~, then
-          1. Let _b_ be 0.
-          1. Let _n_ be 0.
-        1. Else,
-          1. Let _b_ be MV of _fracPart_.
-          1. Let _n_ be the number of code points in _fracPart_.
-          1. Assert: _n_ > 0.
-          1. If _a_ = 0, then
-            1. Let _zn_ be the count of leading U+0030 (DIGIT ZERO) code points in _fracPart_.
-            1. Set _z_ to _z_ + _zn_.
-        1. If _a_ = 0 and _b_ = 0, return « 0, 1 + _n_ ».
-        1. Let _value_ be (_a_ + (_b_ × 10<sup>-_n_</sup>)) × 10<sup>_e_</sup>.
-        1. Let _stringDigitCount_ be _m_ + _n_ - _z_.
-        1. Return the Intl MV Record { [[Value]]: _value_, [[StringDigitCount]]: _stringDigitCount_ }.
-      </emu-alg>
-    </emu-clause>
+          ): an Intl MV Record</ins>
+        </h1>
+        <dl class="header">
+          <dt>description</dt>
+          <dd></dd>
+        </dl>
+        <emu-alg>
+          1. If _intPart_ is ~empty~, then
+            1. Let _a_ be 0.
+            1. Let _m_ be 0.
+            1. Let _z_ be 0.
+          1. Else,
+            1. Let _a_ be MV of _intPart_.
+            1. Let _m_ be the number of code points in _intPart_.
+            1. Assert: _m_ > 0.
+            1. Let _z_ be the count of leading U+0030 (DIGIT ZERO) code points in _intPart_.
+          1. If _fracPart_ is ~empty~, then
+            1. Let _b_ be 0.
+            1. Let _n_ be 0.
+          1. Else,
+            1. Let _b_ be MV of _fracPart_.
+            1. Let _n_ be the number of code points in _fracPart_.
+            1. Assert: _n_ > 0.
+            1. If _a_ = 0, then
+              1. Let _zn_ be the count of leading U+0030 (DIGIT ZERO) code points in _fracPart_.
+              1. Set _z_ to _z_ + _zn_.
+          1. If _a_ = 0 and _b_ = 0, return « 0, 1 + _n_ ».
+          1. Let _value_ be (_a_ + (_b_ × 10<sup>-_n_</sup>)) × 10<sup>_e_</sup>.
+          1. Let _stringDigitCount_ be _m_ + _n_ - _z_.
+          1. Return the Intl MV Record { [[Value]]: _value_, [[StringDigitCount]]: _stringDigitCount_ }.
+        </emu-alg>
+      </emu-clause>
+    </ins>
 
     <emu-clause id="sec-tointlmathematicalvalue" type="abstract operation">
       <h1>

--- a/spec.emu
+++ b/spec.emu
@@ -113,6 +113,51 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
   <emu-clause id="sec-numberformat-abstracts">
     <h1>Abstract Operations for NumberFormat Objects</h1>
 
+    <emu-clause id="sec-intl-mv-records">
+      <h1><ins>Intl MV Records</ins></h1>
+      <p>An <dfn variants="Intl MV Records">Intl MV Record</dfn> is a Record value used to encapsulate a mathematical value together with additional information.</p>
+      <p>Intl MV Records have the fields listed in <emu-xref href="#table-intl-mv-record-fields"></emu-xref>.</p>
+      <emu-table id="table-intl-mv-record-fields" caption="Intl MV Record Fields">
+        <table>
+          <thead>
+            <tr>
+              <th>
+                Field Name
+              </th>
+              <th>
+                Value
+              </th>
+              <th>
+                Meaning
+              </th>
+            </tr>
+          </thead>
+          <tr>
+            <td>
+              [[Value]]
+            </td>
+            <td>
+              a mathematical value or one of ~positive-infinity~, ~negative-infinity~, ~not-a-number~, or ~negative-zero~
+            </td>
+            <td>
+              The value being formatted or selected on.
+            </td>
+          </tr>
+          <tr>
+            <td>
+              [[StringDigitCount]]
+            </td>
+            <td>
+              a non-negative integer
+            </td>
+            <td>
+              The number of decimal digits in [[Value]] when it is derived from a String (ignoring any exponent, and not counting leading zeros), or 0 otherwise.
+            </td>
+          </tr>
+        </table>
+      </emu-table>
+    </emu-clause>
+
     <emu-clause id="sec-formatnumerictostring" oldids="sec-formatnumberstring" type="abstract operation" number="3">
       <h1>
         FormatNumericToString (
@@ -123,7 +168,7 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>It rounds _x_ to an Intl mathematical value according to the internal slots of _intlObject_. The [[RoundedNumber]] field contains the rounded result value and the [[FormattedString]] field contains a String value representation of that result formatted according to the internal slots of _intlObject_.</dd>
+        <dd>It rounds _x_ to <del>an Intl</del><ins>a</ins> mathematical value<ins> or ~negative-zero~</ins> according to the internal slots of _intlObject_. The [[RoundedNumber]] field contains the rounded result value and the [[FormattedString]] field contains a String value representation of that result formatted according to the internal slots of _intlObject_.</dd>
       </dl>
       <emu-alg>
         1. Assert: _intlObject_ has [[RoundingMode]], [[RoundingType]], [[MinimumSignificantDigits]], [[MaximumSignificantDigits]], [[MinimumIntegerDigits]], [[MinimumFractionDigits]], [[MaximumFractionDigits]], [[RoundingIncrement]], and [[TrailingZeroDisplay]] internal slots.
@@ -171,7 +216,7 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
       <h1>
         PartitionNumberPattern (
           _numberFormat_: an object initialized as a NumberFormat,
-          _x_: <ins>a mathematical value or</ins> an Intl mathematical value,
+          _x_: <del>an Intl mathematical value</del><ins>a mathematical value or an Intl MV Record</ins>,
         ): a List of Records with fields [[Type]] (a String) and [[Value]] (a String)
       </h1>
       <dl class="header">
@@ -180,7 +225,7 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
       </dl>
 
       <emu-alg>
-        1. <ins>If _x_ is an Intl mathematical value, then</ins>
+        1. <ins>If _x_ is an Intl MV Record, then</ins>
           1. <ins>Let _stringDigitCount_ be _x_.[[StringDigitCount]].</ins>
           1. <ins>Set _x_ to _x_.[[Value]].</ins>
         1. <ins>Else,</ins>
@@ -312,7 +357,7 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
       <h1>
         FormatNumeric (
           _numberFormat_: an Intl.NumberFormat,
-          _x_: <ins>a mathematical value or</ins> an Intl mathematical value,
+          _x_: <del>an Intl mathematical value</del><ins>a mathematical value or an Intl MV Record</ins>,
         ): a String
       </h1>
       <dl class="header">
@@ -505,14 +550,16 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
         </del>
         <ins class="block">
           <p>
-            The conversion of a |StringNumericLiteral| to a mathematical value and a precision is similar overall to the determination of the NumericValue of a |NumericLiteral| (see <emu-xref href="#sec-literals-numeric-literals"></emu-xref>), but some of the details are different.
-            The result of StringIntlMV is a List value with two elements, a mathematical value and the count of significant decimal digits in the source text.
+            The conversion of a |StringNumericLiteral| to a mathematical value
+            is similar overall to the determination of the NumericValue of a |NumericLiteral| (see <emu-xref href="#sec-literals-numeric-literals"></emu-xref>),
+            but some of the details are different, and additional information is retained.
+            The result of StringIntlMV is an Intl MV Record.
           </p>
         </ins>
       </emu-note>
       <emu-grammar>StringNumericLiteral ::: StrWhiteSpace?</emu-grammar>
       <emu-alg>
-        1. Return <del>0</del><ins>« 0, 0 »</ins>.
+        1. Return <del>0</del><ins>the Intl MV Record { [[Value]]: 0, [[StringDigitCount]]: 0 }</ins>.
       </emu-alg>
       <emu-grammar>StringNumericLiteral ::: StrWhiteSpace? StrNumericLiteral StrWhiteSpace?</emu-grammar>
       <emu-alg>
@@ -522,7 +569,7 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
       <emu-alg>
         1. <del>Return MV of |NonDecimalIntegerLiteral|.</del>
         1. <ins>Let _i_ be MV of |NonDecimalIntegerLiteral|.</ins>
-        1. <ins>Return « _i_, 0 ».</ins>
+        1. <ins>Return the Intl MV Record { [[Value]]: _i_, [[StringDigitCount]]: 0 }.</ins>
       </emu-alg>
       <emu-grammar>StrDecimalLiteral ::: `-` StrUnsignedDecimalLiteral</emu-grammar>
       <emu-alg>
@@ -531,11 +578,11 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
         1. <ins>Let _n_ be the second element of _x_.</ins>
         1. If _a_ is 0, return <del>~negative-zero~</del><ins>« ~negative-zero~, _n_ »</ins>.
         1. If _a_ is ~positive-infinity~, return <del>~negative-infinity~</del><ins>« ~negative-infinity~, 0 »</ins>.
-        1. Return <del>-_a_</del><ins>« -_a_, _n_ »</ins>.
+        1. Return <del>-_a_</del><ins>the Intl MV Record { [[Value]]: -_a_, [[StringDigitCount]]: _n_ }</ins>.
       </emu-alg>
       <emu-grammar>StrUnsignedDecimalLiteral ::: `Infinity`</emu-grammar>
       <emu-alg>
-        1. Return <del>~positive-infinity~</del><ins>« ~positive-infinity~, 0 »</ins>.
+        1. Return <del>~positive-infinity~</del><ins>the Intl MV Record { [[Value]]: ~positive-infinity~, [[StringDigitCount]]: 0 }</ins>.
       </emu-alg>
       <emu-grammar>StrUnsignedDecimalLiteral ::: DecimalDigits `.` DecimalDigits? ExponentPart?</emu-grammar>
       <emu-alg>
@@ -573,14 +620,12 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
             _intPart_: a Parse Node or ~empty~,
             _fracPart_: a Parse Node or ~empty~,
             _e_: a mathematical value,
-          ): a List
+          ): an Intl MV Record
         </ins>
       </h1>
       <dl class="header">
         <dt>description</dt>
-        <dd>
-          The returned List contains two values: a mathematical value corresponding to the source text, and the count of significant decimal digits in the source text.
-        </dd>
+        <dd></dd>
       </dl>
       <emu-alg>
         1. If _intPart_ is ~empty~, then
@@ -603,7 +648,9 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
             1. Let _zn_ be the count of leading U+0030 (DIGIT ZERO) code points in _fracPart_.
             1. Set _z_ to _z_ + _zn_.
         1. If _a_ = 0 and _b_ = 0, return « 0, 1 + _n_ ».
-        1. Return « (_a_ + (_b_ × 10<sup>-_n_</sup>)) × 10<sup>_e_</sup>, _m_ + _n_ - _z_».
+        1. Let _value_ be (_a_ + (_b_ × 10<sup>-_n_</sup>)) × 10<sup>_e_</sup>.
+        1. Let _stringDigitCount_ be _m_ + _n_ - _z_.
+        1. Return the Intl MV Record { [[Value]]: _value_, [[StringDigitCount]]: _stringDigitCount_ }.
       </emu-alg>
     </emu-clause>
 
@@ -616,43 +663,41 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
       <dl class="header">
         <dt>description</dt>
         <dd>
-          It returns _value_ converted to an <dfn id="intl-mathematical-value">Intl mathematical value</dfn>, <del>which</del><ins>a Record with two fields:</ins>
-          <ins>[[Value]]</ins> is a mathematical value <del>together with</del><ins>or one of</ins> ~positive-infinity~, ~negative-infinity~, ~not-a-number~, <ins>or ~negative-zero~,</ins> and
-          <del>~negative-zero~</del><ins>[[StringDigitCount]] is an integer indicating the number of decimal digits in _value_ when it is a String (ignoring any exponent, and not counting leading zeros), or 0 otherwise</ins>.
-          This abstract operation is similar to <emu-xref href="#sec-tonumeric"></emu-xref>, but <del>a mathematical value can be returned instead of a Number or BigInt, so that exact decimal values can be represented</del><ins>retains the full precision of numeric strings</ins>.
+          <del>It returns _value_ converted to an <dfn id="intl-mathematical-value">Intl mathematical value</dfn>, which is a mathematical value together with ~positive-infinity~, ~negative-infinity~, ~not-a-number~, and ~negative-zero~.</del>
+          This abstract operation is similar to <emu-xref href="#sec-tonumeric"></emu-xref>, but <del>a mathematical value can be returned instead of a Number or BigInt, so that exact decimal values can be represented</del><ins>it retains the full precision of numeric strings</ins>.
         </dd>
       </dl>
       <emu-alg>
         1. Let _primValue_ be ? ToPrimitive(_value_, ~number~).
-        1. If _primValue_ is a BigInt, return <del>ℝ(_primValue_)</del><ins>the Record { [[Value]]: ℝ(_primValue_), [[StringDigitCount]]: 0 }</ins>.
+        1. If _primValue_ is a BigInt, return <del>ℝ(_primValue_)</del><ins>the Intl MV Record { [[Value]]: ℝ(_primValue_), [[StringDigitCount]]: 0 }</ins>.
         1. If _primValue_ is a String, then
           1. Let _str_ be _primValue_.
         1. Else,
           1. Let _x_ be ? ToNumber(_primValue_).
-          1. If _x_ is *-0*<sub>𝔽</sub>, return <del>~negative-zero~</del><ins>the Record { [[Value]]: ~negative-zero~, [[StringDigitCount]]: 0 }</ins>.
+          1. If _x_ is *-0*<sub>𝔽</sub>, return <del>~negative-zero~</del><ins>the Intl MV Record { [[Value]]: ~negative-zero~, [[StringDigitCount]]: 0 }</ins>.
           1. Let _str_ be Number::toString(_x_, 10).
         1. Let _text_ be StringToCodePoints(_str_).
         1. Let _literal_ be ParseText(_text_, |StringNumericLiteral|).
-        1. If _literal_ is a List of errors, return <del>~not-a-number~</del><ins>the Record { [[Value]]: ~not-a-number~, [[StringDigitCount]]: 0 }</ins>.
+        1. If _literal_ is a List of errors, return <del>~not-a-number~</del><ins>the Intl MV Record { [[Value]]: ~not-a-number~, [[StringDigitCount]]: 0 }</ins>.
         1. Let <del>_intlMV_</del><ins>_stringData_</ins> be the StringIntlMV of _literal_.
-        1. <ins>Let _intlMV_ be _stringData_[0].</ins>
+        1. <ins>Let _value_ be _stringData_.[[Value]].</ins>
         1. <ins>If _primValue_ is a String, then</ins>
-          1. <ins>Let _stringDigitCount_ be _stringData_[1].</ins>
+          1. <ins>Let _stringDigitCount_ be _stringData_.[[StringDigitCount]].</ins>
         1. <ins>Else,</ins>
           1. <ins>Let _stringDigitCount_ be 0.</ins>
-        1. If _intlMV_ is a mathematical value, then
-          1. Let _rounded_ be RoundMVResult(abs(_intlMV_)).
+        1. If <del>_intlMV_</del><ins>_value_</ins> is a mathematical value, then
+          1. Let _rounded_ be RoundMVResult(abs(<del>_intlMV_</del><ins>_value_</ins>)).
           1. <del>If _rounded_ is *+∞*<sub>𝔽</sub> and _intlMV_ &lt; 0, return ~negative-infinity~.</del>
           1. <del>If _rounded_ is *+∞*<sub>𝔽</sub>, return ~positive-infinity~.</del>
           1. <ins>If _rounded_ is *+∞*<sub>𝔽</sub>, then</ins>
-            1. <ins>If _intlMV_ &lt; 0, set _intlMV_ to ~negative-infinity~; else set _intlMV_ to ~positive-infinity~.</ins>
+            1. <ins>If _value_ &lt; 0, set _value_ to ~negative-infinity~; else set _value_ to ~positive-infinity~.</ins>
             1. <ins>Set _stringDigitCount_ to 0.</ins>
           1. <del>If _rounded_ is *+0*<sub>𝔽</sub> and _intlMV_ &lt; 0, return ~negative-zero~.</del>
           1. <del>If _rounded_ is *+0*<sub>𝔽</sub>, return 0.</del>
           1. <ins>Else if _rounded_ is *+0*<sub>𝔽</sub>, then</ins>
-            1. <ins>If _intlMV_ &lt; 0, set _intlMV_ to ~negative-zero~; else set _intlMV_ to 0.</ins>
+            1. <ins>If _value_ &lt; 0, set _value_ to ~negative-zero~; else set _value_ to 0.</ins>
             1. NOTE: The value of _stringDigitCount_ is retained.
-        1. Return <del>_intlMV_</del><ins>the Record { [[Value]]: _intlMV_, [[StringDigitCount]]: _stringDigitCount_ }</ins>.
+        1. Return <del>_intlMV_</del><ins>the Intl MV Record { [[Value]]: _value_, [[StringDigitCount]]: _stringDigitCount_ }</ins>.
       </emu-alg>
     </emu-clause>
 
@@ -660,8 +705,8 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
       <h1>
         PartitionNumberRangePattern (
           _numberFormat_: an Intl.NumberFormat,
-          _x_: an Intl mathematical value,
-          _y_: an Intl mathematical value,
+          _x_: an <del>Intl mathematical value</del><ins>Intl MV Record</ins>,
+          _y_: an <del>mIntl athematical value</del><ins>Intl MV Record</ins>,
         ): either a normal completion containing a List of Records with fields [[Type]] (a String), [[Value]] (a String), and [[Source]] (a String), or a throw completion
       </h1>
       <dl class="header">
@@ -710,7 +755,7 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
         ResolvePlural (
           _pluralRules_: an Intl.PluralRules,
           <del>_n_: an Intl mathematical value,</del>
-          <ins>_intlMV_: an Intl mathematical value,</ins>
+          <ins>_intlMV_: an Intl MV Record,</ins>
         ): a Record with fields [[PluralCategory]] (*"zero"*, *"one"*, *"two"*, *"few"*, *"many"*, or *"other"*) and [[FormattedString]] (a String)
       </h1>
       <dl class="header">
@@ -744,8 +789,8 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
       <h1>
         ResolvePluralRange (
           _pluralRules_: an Intl.PluralRules,
-          _x_: an Intl mathematical value,
-          _y_: an Intl mathematical value,
+          _x_: an <del>Intl mathematical value</del><ins>Intl MV Record</ins>,
+          _y_: an <del>Intl mathematical value</del><ins>Intl MV Record</ins>,
         ): either a normal completion containing either *"zero"*, *"one"*, *"two"*, *"few"*, *"many"*, or *"other"*, or a throw completion
       </h1>
       <dl class="header">

--- a/spec.emu
+++ b/spec.emu
@@ -177,8 +177,8 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
         FormatNumericToString (
           _intlObject_: an Object,
           _x_: a mathematical value or ~negative-zero~,
-          <ins>_stringDigitCount_: an integer,</ins>
-          <ins>_stringFractionDigitCount_: an integer,</ins>
+          <ins>_digitCount_: an integer,</ins>
+          <ins>_fractionDigitCount_: an integer,</ins>
         ): a Record with fields [[RoundedNumber]] (a mathematical value or ~negative-zero~) and [[FormattedString]] (a String)
       </h1>
       <dl class="header">
@@ -196,16 +196,16 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
           1. If _sign_ is ~negative~, then
             1. Set _x_ to -_x_.
         1. <ins>If _intlObject_.[[TrailingZeroDisplay]] is *"stripToMinimum"*, then</ins>
-          1. <ins>Set _stringDigitCount_ to 0.</ins>
-          1. <ins>Set _stringFractionDigitCount_ to 0.</ins>
+          1. <ins>Set _digitCount_ to 0.</ins>
+          1. <ins>Set _fractionDigitCount_ to 0.</ins>
         1. Let _unsignedRoundingMode_ be GetUnsignedRoundingMode(_intlObject_.[[RoundingMode]], _sign_).
         1. If _intlObject_.[[RoundingType]] is ~significant-digits~, then
-          1. Let _result_ be ToRawPrecision(_x_, <ins>_stringDigitCount_, _stringFractionDigitCount_,</ins> _intlObject_.[[MinimumSignificantDigits]], _intlObject_.[[MaximumSignificantDigits]], _unsignedRoundingMode_).
+          1. Let _result_ be ToRawPrecision(_x_, <ins>_digitCount_, _fractionDigitCount_,</ins> _intlObject_.[[MinimumSignificantDigits]], _intlObject_.[[MaximumSignificantDigits]], _unsignedRoundingMode_).
         1. Else if _intlObject_.[[RoundingType]] is ~fraction-digits~, then
-          1. Let _result_ be ToRawFixed(_x_, <ins>_stringDigitCount_, _stringFractionDigitCount_,</ins> _intlObject_.[[MinimumFractionDigits]], _intlObject_.[[MaximumFractionDigits]], _intlObject_.[[RoundingIncrement]], _unsignedRoundingMode_).
+          1. Let _result_ be ToRawFixed(_x_, <ins>_digitCount_, _fractionDigitCount_,</ins> _intlObject_.[[MinimumFractionDigits]], _intlObject_.[[MaximumFractionDigits]], _intlObject_.[[RoundingIncrement]], _unsignedRoundingMode_).
         1. Else,
-          1. Let _sResult_ be ToRawPrecision(_x_, <ins>_stringDigitCount_, _stringFractionDigitCount_,</ins> _intlObject_.[[MinimumSignificantDigits]], _intlObject_.[[MaximumSignificantDigits]], _unsignedRoundingMode_).
-          1. Let _fResult_ be ToRawFixed(_x_, <ins>_stringDigitCount_, _stringFractionDigitCount_,</ins> _intlObject_.[[MinimumFractionDigits]], _intlObject_.[[MaximumFractionDigits]], _intlObject_.[[RoundingIncrement]], _unsignedRoundingMode_).
+          1. Let _sResult_ be ToRawPrecision(_x_, <ins>_digitCount_, _fractionDigitCount_,</ins> _intlObject_.[[MinimumSignificantDigits]], _intlObject_.[[MaximumSignificantDigits]], _unsignedRoundingMode_).
+          1. Let _fResult_ be ToRawFixed(_x_, <ins>_digitCount_, _fractionDigitCount_,</ins> _intlObject_.[[MinimumFractionDigits]], _intlObject_.[[MaximumFractionDigits]], _intlObject_.[[RoundingIncrement]], _unsignedRoundingMode_).
           1. If _fResult_.[[RoundingMagnitude]] &lt; _sResult_.[[RoundingMagnitude]], let _fixedIsMorePrecise_ be *true*; else let _fixedIsMorePrecise_ be *false*.
           1. If _intlObject_.[[RoundingType]] is ~more-precision~ and _fixedIsMorePrecise_ is *true*, then
             1. Let _result_ be _fResult_.
@@ -243,13 +243,13 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
 
       <emu-alg>
         1. <ins>If _x_ is an Intl MV Record, then</ins>
-          1. <ins>Let _stringDigitCount_ be _x_.[[StringDigitCount]].</ins>
-          1. <ins>Let _stringFractionDigitCount_ be _x_.[[StringFractionDigitCount]].</ins>
+          1. <ins>Let _digitCount_ be _x_.[[StringDigitCount]].</ins>
+          1. <ins>Let _fractionDigitCount_ be _x_.[[StringFractionDigitCount]].</ins>
           1. <ins>Set _x_ to _x_.[[Value]].</ins>
         1. <ins>Else,</ins>
           1. <ins>Assert: _x_ is a mathematical value.</ins>
-          1. <ins>Let _stringDigitCount_ be 0.</ins>
-          1. <ins>Let _stringFractionDigitCount_ be 0.</ins>
+          1. <ins>Let _digitCount_ be 0.</ins>
+          1. <ins>Let _fractionDigitCount_ be 0.</ins>
         1. Let _exponent_ be 0.
         1. If _x_ is ~not-a-number~, then
           1. Let _n_ be an ILD String value indicating the *NaN* value.
@@ -263,7 +263,7 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
             1. If _numberFormat_.[[Style]] is *"percent"*, set _x_ <del>be</del><ins>to</ins> 100 × _x_.
             1. Set _exponent_ to ComputeExponent(_numberFormat_, _x_).
             1. Set _x_ to _x_ × 10<sup>-_exponent_</sup>.
-          1. Let _formatNumberResult_ be FormatNumericToString(_numberFormat_, _x_<ins>, _stringDigitCount_, _stringFractionDigitCount_</ins>).
+          1. Let _formatNumberResult_ be FormatNumericToString(_numberFormat_, _x_<ins>, _digitCount_, _fractionDigitCount_</ins>).
           1. Let _n_ be _formatNumberResult_.[[FormattedString]].
           1. Set _x_ to _formatNumberResult_.[[RoundedNumber]].
         1. Let _pattern_ be GetNumberFormatPattern(_numberFormat_, _x_).
@@ -394,8 +394,8 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
       <h1>
         ToRawPrecision (
           _x_: a non-negative mathematical value,
-          <ins>_stringDigitCount_: an integer,</ins>
-          <ins>_stringFractionDigitCount_: an integer,</ins>
+          <ins>_digitCount_: an integer,</ins>
+          <ins>_fractionDigitCount_: an integer,</ins>
           _minPrecision_: an integer in the inclusive interval from 1 to 21,
           _maxPrecision_: an integer in the inclusive interval from 1 to 21,
           _unsignedRoundingMode_: a specification type from the Unsigned Rounding Mode column of <emu-xref href="#table-intl-unsigned-rounding-modes"></emu-xref>, or *undefined*,
@@ -439,7 +439,7 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
           1. Assert: _e_ &lt; 0.
           1. Set _m_ to the string-concatenation of *"0."*, -(_e_ + 1) occurrences of the code unit 0x0030 (DIGIT ZERO), and _m_.
           1. Let _int_ be 1.
-        1. <ins>If _isZero_ is *true*, let _resolvedMinPrecision_ be max(_minPrecision_, _stringFractionDigitCount_ + 1); else let _resolvedMinPrecision_ be max(_minPrecision_, _stringDigitCount_).</ins>
+        1. <ins>If _isZero_ is *true*, let _resolvedMinPrecision_ be max(_minPrecision_, _fractionDigitCount_ + 1); else let _resolvedMinPrecision_ be max(_minPrecision_, _digitCount_).</ins>
         1. If _m_ contains the code unit 0x002E (FULL STOP) and _maxPrecision_ > <del>_minPrecision_</del><ins>_resolvedMinPrecision_</ins>, then
           1. Let _cut_ be _maxPrecision_ - <del>_minPrecision_</del><ins>_resolvedMinPrecision_</ins>.
           1. Repeat, while _cut_ > 0 and the last code unit of _m_ is 0x0030 (DIGIT ZERO),
@@ -455,8 +455,8 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
       <h1>
         ToRawFixed (
           _x_: a non-negative mathematical value,
-          <ins>_stringDigitCount_: an integer,</ins>
-          <ins>_stringFractionDigitCount_: an integer,</ins>
+          <ins>_digitCount_: an integer,</ins>
+          <ins>_fractionDigitCount_: an integer,</ins>
           _minFraction_: an integer in the inclusive interval from 0 to 100,
           _maxFraction_: an integer in the inclusive interval from 0 to 100,
           _roundingIncrement_: an integer,
@@ -492,11 +492,11 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
           1. <del>Set _m_ to the string-concatenation of _a_, *"."*, and _b_.</del>
           1. Let _int_ be the length of _a_.
           1. <ins>If every code unit of _m_ is 0x0030 (DIGIT ZERO), then</ins>
-            1. <ins>Let _sfc_ be _stringFractionDigitCount_.</ins>
+            1. <ins>Let _sfc_ be _fractionDigitCount_.</ins>
           1. <ins>Else if _n_ = 0, then</ins>
-            1. <ins>Let _sfc_ be _stringDigitCount_ - _int_.</ins>
+            1. <ins>Let _sfc_ be _digitCount_ - _int_.</ins>
           1. <ins>Else,</ins>
-            1. <ins>Let _sfc_ be _stringDigitCount_ - _int_ + _zn_.</ins>
+            1. <ins>Let _sfc_ be _digitCount_ - _int_ + _zn_.</ins>
           1. <ins>Let _cut_ be _maxFraction_ - max(_sfc_, _minFraction_).</ins>
           1. <ins>Repeat, while _cut_ > 0 and the last code unit of _b_ is 0x0030 (DIGIT ZERO),</ins>
             1. <ins>Remove the last code unit from _b_.</ins>
@@ -675,9 +675,9 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
               1. Let _zn_ be the count of leading U+0030 (DIGIT ZERO) code points in _fracPart_.
               1. Set _z_ to _z_ + _zn_.
           1. Let _value_ be (_a_ + (_b_ × 10<sup>-_n_</sup>)) × 10<sup>_e_</sup>.
-          1. If _a_ = 0 and _b_ = 0, let _stringDigitCount_ be 1 + _n_; else let _stringDigitCount_ be _m_ + _n_ - _z_.
-          1. Let _stringFractionDigitCount_ be max(0, _n_ - _e_).
-          1. Return the Intl MV Record { [[Value]]: _value_, [[StringDigitCount]]: _stringDigitCount_, [[StringFractionDigitCount]]: _stringFractionDigitCount_ }.
+          1. If _a_ = 0 and _b_ = 0, let _digitCount_ be 1 + _n_; else let _digitCount_ be _m_ + _n_ - _z_.
+          1. Let _fractionDigitCount_ be max(0, _n_ - _e_).
+          1. Return the Intl MV Record { [[Value]]: _value_, [[StringDigitCount]]: _digitCount_, [[StringFractionDigitCount]]: _fractionDigitCount_ }.
         </emu-alg>
       </emu-clause>
     </ins>
@@ -710,24 +710,24 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
         1. Let <del>_intlMV_</del><ins>_stringData_</ins> be the StringIntlMV of _literal_.
         1. <ins>Let _value_ be _stringData_.[[Value]].</ins>
         1. <ins>If _primValue_ is a String, then</ins>
-          1. <ins>Let _stringDigitCount_ be _stringData_.[[StringDigitCount]].</ins>
-          1. <ins>Let _stringFractionDigitCount_ be _stringData_.[[StringFractionDigitCount]].</ins>
+          1. <ins>Let _digitCount_ be _stringData_.[[StringDigitCount]].</ins>
+          1. <ins>Let _fractionDigitCount_ be _stringData_.[[StringFractionDigitCount]].</ins>
         1. <ins>Else,</ins>
-          1. <ins>Let _stringDigitCount_ be 0.</ins>
-          1. <ins>Let _stringFractionDigitCount_ be 0.</ins>
+          1. <ins>Let _digitCount_ be 0.</ins>
+          1. <ins>Let _fractionDigitCount_ be 0.</ins>
         1. If <del>_intlMV_</del><ins>_value_</ins> is a mathematical value, then
           1. Let _rounded_ be RoundMVResult(abs(<del>_intlMV_</del><ins>_value_</ins>)).
           1. <del>If _rounded_ is *+∞*<sub>𝔽</sub> and _intlMV_ &lt; 0, return ~negative-infinity~.</del>
           1. <del>If _rounded_ is *+∞*<sub>𝔽</sub>, return ~positive-infinity~.</del>
           1. <ins>If _rounded_ is *+∞*<sub>𝔽</sub>, then</ins>
             1. <ins>If _value_ &lt; 0, set _value_ to ~negative-infinity~; else set _value_ to ~positive-infinity~.</ins>
-            1. <ins>Set _stringDigitCount_ to 0.</ins>
+            1. <ins>Set _digitCount_ to 0.</ins>
           1. <del>If _rounded_ is *+0*<sub>𝔽</sub> and _intlMV_ &lt; 0, return ~negative-zero~.</del>
           1. <del>If _rounded_ is *+0*<sub>𝔽</sub>, return 0.</del>
           1. <ins>Else if _rounded_ is *+0*<sub>𝔽</sub>, then</ins>
             1. <ins>If _value_ &lt; 0, set _value_ to ~negative-zero~; else set _value_ to 0.</ins>
-            1. NOTE: The value of _stringDigitCount_ is retained.
-        1. Return <del>_intlMV_</del><ins>the Intl MV Record { [[Value]]: _value_, [[StringDigitCount]]: _stringDigitCount_, [[StringFractionDigitCount]]: _stringFractionDigitCount_ }</ins>.
+            1. NOTE: The value of _digitCount_ is retained.
+        1. Return <del>_intlMV_</del><ins>the Intl MV Record { [[Value]]: _value_, [[StringDigitCount]]: _digitCount_, [[StringFractionDigitCount]]: _fractionDigitCount_ }</ins>.
       </emu-alg>
     </emu-clause>
 
@@ -803,9 +803,9 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
         1. If _n_ is ~negative-infinity~, then
           1. Let _s_ be an ILD String value indicating negative infinity.
           1. Return the Record { [[PluralCategory]]: *"other"*, [[FormattedString]]: _s_ }.
-        1. <ins>Let _stringDigitCount_ be _intlMV_.[[StringDigitCount]].</ins>
-        1. <ins>Let _stringFractionDigitCount_ be _intlMV_.[[StringFractionDigitCount]].</ins>
-        1. Let _res_ be FormatNumericToString(_pluralRules_, _n_<ins>, _stringDigitCount_, _stringFractionDigitCount_</ins>).
+        1. <ins>Let _digitCount_ be _intlMV_.[[StringDigitCount]].</ins>
+        1. <ins>Let _fractionDigitCount_ be _intlMV_.[[StringFractionDigitCount]].</ins>
+        1. Let _res_ be FormatNumericToString(_pluralRules_, _n_<ins>, _digitCount_, _fractionDigitCount_</ins>).
         1. Let _s_ be _res_.[[FormattedString]].
         1. Let _locale_ be _pluralRules_.[[Locale]].
         1. Let _type_ be _pluralRules_.[[Type]].

--- a/spec.emu
+++ b/spec.emu
@@ -156,6 +156,17 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
                 The number of decimal digits in [[Value]] when it is derived from a String (before applying its exponent part, and ignoring leading zeros), or 0 otherwise.
               </td>
             </tr>
+          <tr>
+            <td>
+              [[MVFractionDigitCount]]
+            </td>
+            <td>
+              a non-negative integer
+            </td>
+            <td>
+              The number of decimal fraction digits in [[Value]] when it is derived from a String (based on its mathemetical value, so accounting for any exponent), or 0 otherwise.
+            </td>
+          </tr>
           </table>
         </emu-table>
       </emu-clause>
@@ -167,6 +178,7 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
           _intlObject_: an Object,
           _x_: a mathematical value or ~negative-zero~,
           <ins>_stringDigitCount_: an integer,</ins>
+          <ins>_mvFractionDigitCount_: an integer,</ins>
         ): a Record with fields [[RoundedNumber]] (a mathematical value or ~negative-zero~) and [[FormattedString]] (a String)
       </h1>
       <dl class="header">
@@ -183,15 +195,17 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
           1. If _x_ &lt; 0, let _sign_ be ~negative~; else let _sign_ be ~positive~.
           1. If _sign_ is ~negative~, then
             1. Set _x_ to -_x_.
-        1. <ins>If _intlObject_.[[TrailingZeroDisplay]] is *"stripToMinimum"*, set _stringDigitCount_ to 0.</ins>
+        1. <ins>If _intlObject_.[[TrailingZeroDisplay]] is *"stripToMinimum"*, then</ins>
+          1. <ins>Set _stringDigitCount_ to 0.</ins>
+          1. <ins>Set _mvFractionDigitCount_ to 0.</ins>
         1. Let _unsignedRoundingMode_ be GetUnsignedRoundingMode(_intlObject_.[[RoundingMode]], _sign_).
         1. If _intlObject_.[[RoundingType]] is ~significant-digits~, then
-          1. Let _result_ be ToRawPrecision(_x_, <ins>_stringDigitCount_,</ins> _intlObject_.[[MinimumSignificantDigits]], _intlObject_.[[MaximumSignificantDigits]], _unsignedRoundingMode_).
+          1. Let _result_ be ToRawPrecision(_x_, <ins>_stringDigitCount_, _mvFractionDigitCount_,</ins> _intlObject_.[[MinimumSignificantDigits]], _intlObject_.[[MaximumSignificantDigits]], _unsignedRoundingMode_).
         1. Else if _intlObject_.[[RoundingType]] is ~fraction-digits~, then
-          1. Let _result_ be ToRawFixed(_x_, <ins>_stringDigitCount_,</ins> _intlObject_.[[MinimumFractionDigits]], _intlObject_.[[MaximumFractionDigits]], _intlObject_.[[RoundingIncrement]], _unsignedRoundingMode_).
+          1. Let _result_ be ToRawFixed(_x_, <ins>_stringDigitCount_, _mvFractionDigitCount_,</ins> _intlObject_.[[MinimumFractionDigits]], _intlObject_.[[MaximumFractionDigits]], _intlObject_.[[RoundingIncrement]], _unsignedRoundingMode_).
         1. Else,
-          1. Let _sResult_ be ToRawPrecision(_x_, <ins>_stringDigitCount_,</ins> _intlObject_.[[MinimumSignificantDigits]], _intlObject_.[[MaximumSignificantDigits]], _unsignedRoundingMode_).
-          1. Let _fResult_ be ToRawFixed(_x_, <ins>_stringDigitCount_,</ins> _intlObject_.[[MinimumFractionDigits]], _intlObject_.[[MaximumFractionDigits]], _intlObject_.[[RoundingIncrement]], _unsignedRoundingMode_).
+          1. Let _sResult_ be ToRawPrecision(_x_, <ins>_stringDigitCount_, _mvFractionDigitCount_,</ins> _intlObject_.[[MinimumSignificantDigits]], _intlObject_.[[MaximumSignificantDigits]], _unsignedRoundingMode_).
+          1. Let _fResult_ be ToRawFixed(_x_, <ins>_stringDigitCount_, _mvFractionDigitCount_,</ins> _intlObject_.[[MinimumFractionDigits]], _intlObject_.[[MaximumFractionDigits]], _intlObject_.[[RoundingIncrement]], _unsignedRoundingMode_).
           1. If _fResult_.[[RoundingMagnitude]] &lt; _sResult_.[[RoundingMagnitude]], let _fixedIsMorePrecise_ be *true*; else let _fixedIsMorePrecise_ be *false*.
           1. If _intlObject_.[[RoundingType]] is ~more-precision~ and _fixedIsMorePrecise_ is *true*, then
             1. Let _result_ be _fResult_.
@@ -230,10 +244,12 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
       <emu-alg>
         1. <ins>If _x_ is an Intl MV Record, then</ins>
           1. <ins>Let _stringDigitCount_ be _x_.[[StringDigitCount]].</ins>
+          1. <ins>Let _mvFractionDigitCount_ be _x_.[[MVFractionDigitCount]].</ins>
           1. <ins>Set _x_ to _x_.[[Value]].</ins>
         1. <ins>Else,</ins>
           1. <ins>Assert: _x_ is a mathematical value.</ins>
           1. <ins>Let _stringDigitCount_ be 0.</ins>
+          1. <ins>Let _mvFractionDigitCount_ be 0.</ins>
         1. Let _exponent_ be 0.
         1. If _x_ is ~not-a-number~, then
           1. Let _n_ be an ILD String value indicating the *NaN* value.
@@ -244,10 +260,10 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
         1. Else,
           1. If _x_ is not ~negative-zero~, then
             1. Assert: _x_ is a mathematical value.
-            1. If _numberFormat_.[[Style]] is *"percent"*, set _x_ be 100 × _x_.
+            1. If _numberFormat_.[[Style]] is *"percent"*, set _x_ <del>be</del><ins>to</ins> 100 × _x_.
             1. Set _exponent_ to ComputeExponent(_numberFormat_, _x_).
             1. Set _x_ to _x_ × 10<sup>-_exponent_</sup>.
-          1. Let _formatNumberResult_ be FormatNumericToString(_numberFormat_, _x_<ins>, _stringDigitCount_</ins>).
+          1. Let _formatNumberResult_ be FormatNumericToString(_numberFormat_, _x_<ins>, _stringDigitCount_, _mvFractionDigitCount_</ins>).
           1. Let _n_ be _formatNumberResult_.[[FormattedString]].
           1. Set _x_ to _formatNumberResult_.[[RoundedNumber]].
         1. Let _pattern_ be GetNumberFormatPattern(_numberFormat_, _x_).
@@ -347,7 +363,7 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
               1. Let _minusSignSymbol_ be the ILND String representing the minus sign.
               1. Append the Record { [[Type]]: *"exponentMinusSign"*, [[Value]]: _minusSignSymbol_ } to _result_.
               1. Let _exponent_ be -_exponent_.
-            1. Let _exponentResult_ be ToRawFixed(_exponent_,<ins> 0,</ins> 0, 0, 1, *undefined*).
+            1. Let _exponentResult_ be ToRawFixed(_exponent_,<ins> 0, 0,</ins> 0, 0, 1, *undefined*).
             1. Append the Record { [[Type]]: *"exponentInteger"*, [[Value]]: _exponentResult_.[[FormattedString]] } to _result_.
           1. Else,
             1. Let _unknown_ be an ILND String based on _x_ and _p_.
@@ -379,6 +395,7 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
         ToRawPrecision (
           _x_: a non-negative mathematical value,
           <ins>_stringDigitCount_: an integer,</ins>
+          <ins>_mvFractionDigitCount_: an integer,</ins>
           _minPrecision_: an integer in the inclusive interval from 1 to 21,
           _maxPrecision_: an integer in the inclusive interval from 1 to 21,
           _unsignedRoundingMode_: a specification type from the Unsigned Rounding Mode column of <emu-xref href="#table-intl-unsigned-rounding-modes"></emu-xref>, or *undefined*,
@@ -411,6 +428,7 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
             1. Let _n_ be _n2_.
             1. Let _e_ be _e2_.
           1. Let _m_ be the String consisting of the digits of the decimal representation of _n_ (in order, with no leading zeroes).
+        1. <ins>If every code unit of _m_ is 0x0030 (DIGIT ZERO), let _isZero_ be *true*; else let _isZero_ be *false*.</ins>
         1. If _e_ ≥ (_p_ - 1), then
           1. Set _m_ to the string-concatenation of _m_ and _e_ - _p_ + 1 occurrences of the code unit 0x0030 (DIGIT ZERO).
           1. Let _int_ be _e_ + 1.
@@ -421,7 +439,7 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
           1. Assert: _e_ &lt; 0.
           1. Set _m_ to the string-concatenation of *"0."*, -(_e_ + 1) occurrences of the code unit 0x0030 (DIGIT ZERO), and _m_.
           1. Let _int_ be 1.
-        1. <ins>Let _resolvedMinPrecision_ be max(_minPrecision_, _stringDigitCount_).</ins>
+        1. <ins>If _isZero_ is *true*, let _resolvedMinPrecision_ be max(_minPrecision_, _mvFractionDigitCount_ + 1); else let _resolvedMinPrecision_ be max(_minPrecision_, _stringDigitCount_).</ins>
         1. If _m_ contains the code unit 0x002E (FULL STOP) and _maxPrecision_ > <del>_minPrecision_</del><ins>_resolvedMinPrecision_</ins>, then
           1. Let _cut_ be _maxPrecision_ - <del>_minPrecision_</del><ins>_resolvedMinPrecision_</ins>.
           1. Repeat, while _cut_ > 0 and the last code unit of _m_ is 0x0030 (DIGIT ZERO),
@@ -438,6 +456,7 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
         ToRawFixed (
           _x_: a non-negative mathematical value,
           <ins>_stringDigitCount_: an integer,</ins>
+          <ins>_mvFractionDigitCount_: an integer,</ins>
           _minFraction_: an integer in the inclusive interval from 0 to 100,
           _maxFraction_: an integer in the inclusive interval from 0 to 100,
           _roundingIncrement_: an integer,
@@ -472,7 +491,12 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
           1. Let _a_ be the first _k_ - _f_ code units of _m_, and let _b_ be the remaining _f_ code units of _m_.
           1. <del>Set _m_ to the string-concatenation of _a_, *"."*, and _b_.</del>
           1. Let _int_ be the length of _a_.
-          1. <ins>If _n_ = 0, let _sfc_ be _stringDigitCount_ - _int_; else let _sfc_ be _stringDigitCount_ - _int_ + _zn_.</ins>
+          1. <ins>If every code unit of _m_ is 0x0030 (DIGIT ZERO), then</ins>
+            1. <ins>Let _sfc_ be _mvFractionDigitCount_.</ins>
+          1. <ins>Else if _n_ = 0, then</ins>
+            1. <ins>Let _sfc_ be _stringDigitCount_ - _int_.</ins>
+          1. <ins>Else,</ins>
+            1. <ins>Let _sfc_ be _stringDigitCount_ - _int_ + _zn_.</ins>
           1. <ins>Let _cut_ be _maxFraction_ - max(_sfc_, _minFraction_).</ins>
           1. <ins>Repeat, while _cut_ > 0 and the last code unit of _b_ is 0x0030 (DIGIT ZERO),</ins>
             1. <ins>Remove the last code unit from _b_.</ins>
@@ -530,7 +554,7 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
         1. Let _magnitude_ be floor(log10(_x_)).
         1. Let _exponent_ be ComputeExponentForMagnitude(_numberFormat_, _magnitude_).
         1. Let _x_ be _x_ × 10<sup>-_exponent_</sup>.
-        1. Let _formatNumberResult_ be FormatNumericToString(_numberFormat_, _x_<ins>, 0</ins>).
+        1. Let _formatNumberResult_ be FormatNumericToString(_numberFormat_, _x_<ins>, 0, 0</ins>).
         1. If _formatNumberResult_.[[RoundedNumber]] = 0, then
           1. Return _exponent_.
         1. Let _newMagnitude_ be floor(log10(_formatNumberResult_.[[RoundedNumber]])).
@@ -562,7 +586,7 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
       </emu-note>
       <emu-grammar>StringNumericLiteral ::: StrWhiteSpace?</emu-grammar>
       <emu-alg>
-        1. Return <del>0</del><ins>the Intl MV Record { [[Value]]: 0, [[StringDigitCount]]: 0 }</ins>.
+        1. Return <del>0</del><ins>the Intl MV Record { [[Value]]: 0, [[StringDigitCount]]: 0, [[MVFractionDigitCount]]: 0 }</ins>.
       </emu-alg>
       <emu-grammar>StringNumericLiteral ::: StrWhiteSpace? StrNumericLiteral StrWhiteSpace?</emu-grammar>
       <emu-alg>
@@ -572,7 +596,7 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
       <emu-alg>
         1. <del>Return MV of |NonDecimalIntegerLiteral|.</del>
         1. <ins>Let _i_ be MV of |NonDecimalIntegerLiteral|.</ins>
-        1. <ins>Return the Intl MV Record { [[Value]]: _i_, [[StringDigitCount]]: 0 }.</ins>
+        1. <ins>Return the Intl MV Record { [[Value]]: _i_, [[StringDigitCount]]: 0, [[MVFractionDigitCount]]: 0 }.</ins>
       </emu-alg>
       <emu-grammar>StrDecimalLiteral ::: `-` StrUnsignedDecimalLiteral</emu-grammar>
       <emu-alg>
@@ -585,7 +609,7 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
       </emu-alg>
       <emu-grammar>StrUnsignedDecimalLiteral ::: `Infinity`</emu-grammar>
       <emu-alg>
-        1. Return <del>~positive-infinity~</del><ins>the Intl MV Record { [[Value]]: ~positive-infinity~, [[StringDigitCount]]: 0 }</ins>.
+        1. Return <del>~positive-infinity~</del><ins>the Intl MV Record { [[Value]]: ~positive-infinity~, [[StringDigitCount]]: 0, [[MVFractionDigitCount]]: 0 }</ins>.
       </emu-alg>
       <emu-grammar>StrUnsignedDecimalLiteral ::: DecimalDigits `.` DecimalDigits? ExponentPart?</emu-grammar>
       <emu-alg>
@@ -653,7 +677,8 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
           1. If _a_ = 0 and _b_ = 0, return « 0, 1 + _n_ ».
           1. Let _value_ be (_a_ + (_b_ × 10<sup>-_n_</sup>)) × 10<sup>_e_</sup>.
           1. Let _stringDigitCount_ be _m_ + _n_ - _z_.
-          1. Return the Intl MV Record { [[Value]]: _value_, [[StringDigitCount]]: _stringDigitCount_ }.
+          1. Let _mvFractionDigitCount_ be max(0, _n_ - _e_).
+          1. Return the Intl MV Record { [[Value]]: _value_, [[StringDigitCount]]: _stringDigitCount_, [[MVFractionDigitCount]]: _mvFractionDigitCount_ }.
         </emu-alg>
       </emu-clause>
     </ins>
@@ -673,22 +698,24 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
       </dl>
       <emu-alg>
         1. Let _primValue_ be ? ToPrimitive(_value_, ~number~).
-        1. If _primValue_ is a BigInt, return <del>ℝ(_primValue_)</del><ins>the Intl MV Record { [[Value]]: ℝ(_primValue_), [[StringDigitCount]]: 0 }</ins>.
+        1. If _primValue_ is a BigInt, return <del>ℝ(_primValue_)</del><ins>the Intl MV Record { [[Value]]: ℝ(_primValue_), [[StringDigitCount]]: 0, [[MVFractionDigitCount]]: 0 }</ins>.
         1. If _primValue_ is a String, then
           1. Let _str_ be _primValue_.
         1. Else,
           1. Let _x_ be ? ToNumber(_primValue_).
-          1. If _x_ is *-0*<sub>𝔽</sub>, return <del>~negative-zero~</del><ins>the Intl MV Record { [[Value]]: ~negative-zero~, [[StringDigitCount]]: 0 }</ins>.
+          1. If _x_ is *-0*<sub>𝔽</sub>, return <del>~negative-zero~</del><ins>the Intl MV Record { [[Value]]: ~negative-zero~, [[StringDigitCount]]: 0, [[MVFractionDigitCount]]: 0 }</ins>.
           1. Let _str_ be Number::toString(_x_, 10).
         1. Let _text_ be StringToCodePoints(_str_).
         1. Let _literal_ be ParseText(_text_, |StringNumericLiteral|).
-        1. If _literal_ is a List of errors, return <del>~not-a-number~</del><ins>the Intl MV Record { [[Value]]: ~not-a-number~, [[StringDigitCount]]: 0 }</ins>.
+        1. If _literal_ is a List of errors, return <del>~not-a-number~</del><ins>the Intl MV Record { [[Value]]: ~not-a-number~, [[StringDigitCount]]: 0, [[MVFractionDigitCount]]: 0 }</ins>.
         1. Let <del>_intlMV_</del><ins>_stringData_</ins> be the StringIntlMV of _literal_.
         1. <ins>Let _value_ be _stringData_.[[Value]].</ins>
         1. <ins>If _primValue_ is a String, then</ins>
           1. <ins>Let _stringDigitCount_ be _stringData_.[[StringDigitCount]].</ins>
+          1. <ins>Let _mvFractionDigitCount_ be _stringData_.[[MVFractionDigitCount]].</ins>
         1. <ins>Else,</ins>
           1. <ins>Let _stringDigitCount_ be 0.</ins>
+          1. <ins>Let _mvFractionDigitCount_ be 0.</ins>
         1. If <del>_intlMV_</del><ins>_value_</ins> is a mathematical value, then
           1. Let _rounded_ be RoundMVResult(abs(<del>_intlMV_</del><ins>_value_</ins>)).
           1. <del>If _rounded_ is *+∞*<sub>𝔽</sub> and _intlMV_ &lt; 0, return ~negative-infinity~.</del>
@@ -701,7 +728,7 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
           1. <ins>Else if _rounded_ is *+0*<sub>𝔽</sub>, then</ins>
             1. <ins>If _value_ &lt; 0, set _value_ to ~negative-zero~; else set _value_ to 0.</ins>
             1. NOTE: The value of _stringDigitCount_ is retained.
-        1. Return <del>_intlMV_</del><ins>the Intl MV Record { [[Value]]: _value_, [[StringDigitCount]]: _stringDigitCount_ }</ins>.
+        1. Return <del>_intlMV_</del><ins>the Intl MV Record { [[Value]]: _value_, [[StringDigitCount]]: _stringDigitCount_, [[MVFractionDigitCount]]: _mvFractionDigitCount_ }</ins>.
       </emu-alg>
     </emu-clause>
 
@@ -778,7 +805,8 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
           1. Let _s_ be an ILD String value indicating negative infinity.
           1. Return the Record { [[PluralCategory]]: *"other"*, [[FormattedString]]: _s_ }.
         1. <ins>Let _stringDigitCount_ be _intlMV_.[[StringDigitCount]].</ins>
-        1. Let _res_ be FormatNumericToString(_pluralRules_, _n_<ins>, _stringDigitCount_</ins>).
+        1. <ins>Let _mvFractionDigitCount_ be _intlMV_.[[MVFractionDigitCount]].</ins>
+        1. Let _res_ be FormatNumericToString(_pluralRules_, _n_<ins>, _stringDigitCount_, _mvFractionDigitCount_</ins>).
         1. Let _s_ be _res_.[[FormattedString]].
         1. Let _locale_ be _pluralRules_.[[Locale]].
         1. Let _type_ be _pluralRules_.[[Type]].

--- a/spec.emu
+++ b/spec.emu
@@ -577,11 +577,11 @@ location: https://tc39.es/proposal-intl-keep-trailing-zeros/
       <emu-grammar>StrDecimalLiteral ::: `-` StrUnsignedDecimalLiteral</emu-grammar>
       <emu-alg>
         1. Let <del>_a_</del><ins>_x_</ins> be StringIntlMV of |StrUnsignedDecimalLiteral|.
-        1. <ins>Let _a_ be the first element of _x_.</ins>
-        1. <ins>Let _n_ be the second element of _x_.</ins>
-        1. If _a_ is 0, return <del>~negative-zero~</del><ins>the Intl MV Record { [[Value]]: ~negative-zero~, [[StringDigitCount]]: _n_ }</ins>.
-        1. If _a_ is ~positive-infinity~, return <del>~negative-infinity~</del><ins>the Intl MV Record { [[Value]]: ~negative-infinity~, [[StringDigitCount]]: 0 }</ins>.
-        1. Return <del>-_a_</del><ins>the Intl MV Record { [[Value]]: -_a_, [[StringDigitCount]]: _n_ }</ins>.
+        1. <ins>Let _a_ be _x_.[[Value]].</ins>
+        1. If _a_ is 0, <del>return ~negative-zero~</del><ins>set _x_.[[Value]] to ~negative-zero~</ins>.
+        1. <del>If</del><ins>Else if</ins> _a_ is ~positive-infinity~, <del>return ~negative-infinity~</del><ins>set _x_.[[Value]] to ~negative-infinity~</ins>.
+        1. <ins>Else, set _x_.[[Value]] to -_a_.</ins>
+        1. Return <del>-_a_</del><ins>_x_</ins>.
       </emu-alg>
       <emu-grammar>StrUnsignedDecimalLiteral ::: `Infinity`</emu-grammar>
       <emu-alg>


### PR DESCRIPTION
Fixes #15

The fraction digit count is now tracked from the parsed decimal digit string, adjusted by any exponent in the string, and stored as [[MVFractionDigitCount]] in the "Intl MV Record" that's introduced in #20. This is then used only when the formatted output is a representation of zero, in which case it's used instead of the [[StringDigitCount]] to determine the number of zeros to retain.

For example, for `'0.001e-2'` the [[MVFractionDigitCount]] is 3 - (-2) = 5, and if it's formatted with `maximumFractionDigits: 3`, the output would be something like `'0.000'`.

I've [implemented](https://github.com/eemeli/formatjs-for-keep-trailing-zeros/commit/73a6137864201afcdb32bf2ee07f679d5282d312) these changes in the polyfill, and will be updating tc39/test262#4608 correspondingly as well.

To keep the changes here easier to review, this PR currently targets the PR #20 branch to build on top of it, but it'll be retargeted to `main` once that PR first lands.

Ping @gibson042 and @sffc for reviews.